### PR TITLE
Modernize build configuration and clarify third-party licensing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,30 @@ SUBDIRS = deps
 mymaui_PROGRAMS = msamtools
 
 # We will also distribute a README.md markdown file
-EXTRA_DIST = README.md LICENSE
+EXTRA_DIST = README.md \
+             LICENSE
+
+# Install msamtools license information
+licensedir = $(datarootdir)/licenses/msamtools
+license_DATA = LICENSE
+
+# Install licenses for third-party code incorporated during the build.
+# samtools and HTSlib are downloaded into the build tree by the
+# dependency build machinery and are therefore not part of EXTRA_DIST.
+install-data-hook:
+	$(MKDIR_P) "$(DESTDIR)$(licensedir)"
+	$(INSTALL_DATA) \
+		"$(builddir)/deps/samtools/samtools-$(samtools_version)/LICENSE" \
+		"$(DESTDIR)$(licensedir)/samtools-LICENSE"
+	$(INSTALL_DATA) \
+		"$(builddir)/deps/samtools/samtools-$(samtools_version)/htslib-$(samtools_version)/LICENSE" \
+		"$(DESTDIR)$(licensedir)/htslib-LICENSE"
+
+uninstall-hook:
+	rm -f \
+		"$(DESTDIR)$(licensedir)/samtools-LICENSE" \
+		"$(DESTDIR)$(licensedir)/htslib-LICENSE"
+	-rmdir "$(DESTDIR)$(licensedir)"
 
 # Where to install the programs
 mymauidir = $(bindir)

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,11 +10,13 @@ mymaui_PROGRAMS = msamtools
 # We will also distribute a README.md markdown file
 EXTRA_DIST = README.md \
              LICENSE \
+             zoe-LICENSE \
              THIRD_PARTY_NOTICES.md
 
 # Install msamtools license information
 licensedir = $(datarootdir)/licenses/msamtools
 license_DATA = LICENSE \
+               zoe-LICENSE \
                THIRD_PARTY_NOTICES.md
 
 # Install licenses for third-party code incorporated during the build.

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,11 +9,13 @@ mymaui_PROGRAMS = msamtools
 
 # We will also distribute a README.md markdown file
 EXTRA_DIST = README.md \
-             LICENSE
+             LICENSE \
+             THIRD_PARTY_NOTICES.md
 
 # Install msamtools license information
 licensedir = $(datarootdir)/licenses/msamtools
-license_DATA = LICENSE
+license_DATA = LICENSE \
+               THIRD_PARTY_NOTICES.md
 
 # Install licenses for third-party code incorporated during the build.
 # samtools and HTSlib are downloaded into the build tree by the

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -48,3 +48,19 @@ distributed under the MIT/Expat License.
 
 The complete copyright and license notice for the version used to build
 msamtools is provided in `htslib-LICENSE`.
+
+## ZOE / SNAP
+
+ZOE / SNAP is developed by Ian Korf.
+
+`zoeTools.c` and `zoeTools.h` are modified, reduced versions of files from
+the ZOE library distributed with SNAP.
+
+Upstream source:
+[https://github.com/KorfLab/SNAP](https://github.com/KorfLab/SNAP)
+
+The versions included in msamtools were re-derived from SNAP commit
+`4ad1e957cd8e68b63857cc1cb3380d39a7b518b1`.
+
+The upstream ZOE/SNAP code is distributed under the MIT License. The complete
+upstream copyright and license notice is provided in `zoe-LICENSE`.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,50 @@
+# Third-party software
+
+msamtools uses third-party components from **samtools** and **HTSlib**.
+
+The msamtools source distribution does **not** bundle the samtools or HTSlib
+source code. During the build process, the required upstream versions are
+downloaded and used to build msamtools.
+
+Binary distributions of msamtools may therefore contain code derived from or
+statically linked with samtools and HTSlib. For such distributions, the
+corresponding upstream license texts are installed alongside msamtools as:
+
+- `samtools-LICENSE`
+- `htslib-LICENSE`
+
+These files are installed together with:
+
+- `LICENSE`
+- `THIRD_PARTY_NOTICES.md`
+
+typically under:
+
+- `share/licenses/msamtools/`
+
+The msamtools Docker image additionally includes the `samtools` executable.
+Its license is covered by the accompanying `samtools-LICENSE` file.
+
+## samtools (v1.9)
+
+samtools is developed by Genome Research Ltd. and the samtools authors and
+contributors.
+
+samtools is available at
+[https://github.com/samtools/samtools](https://github.com/samtools/samtools)
+and distributed under the MIT/Expat License.
+
+The complete copyright and license notice for the version used to build
+msamtools is provided in `samtools-LICENSE`.
+
+## HTSlib (v1.9)
+
+HTSlib is developed by Genome Research Ltd. and the HTSlib authors and
+contributors.
+
+HTSlib is available at
+[https://github.com/samtools/htslib](https://github.com/samtools/htslib)
+distributed under the MIT/Expat License.
+
+The complete copyright and license notice for the version used to build
+msamtools is provided in `htslib-LICENSE`.

--- a/configure.ac
+++ b/configure.ac
@@ -9,8 +9,7 @@ AC_INIT(
     [1.1.3],
     [https://github.com/arumugamlab/msamtools/issues],
     [msamtools],
-    [https://github.com/arumugamlab/msamtools]
-)
+    [https://github.com/arumugamlab/msamtools])
 
 # we need the aux_dir for installing config.guess to bin/ later.
 # So store it in a variable now, and use AC_SUBST later
@@ -18,7 +17,7 @@ AC_INIT(
 AC_CONFIG_AUX_DIR([build-aux])
 aux_files_dir=build-aux
 
-AM_INIT_AUTOMAKE([1.16.5 -Wall foreign tar-pax subdir-objects])
+AM_INIT_AUTOMAKE([1.15 -Wall foreign tar-pax subdir-objects])
 
 #######################################################
 # Compilers and build tools

--- a/configure.ac
+++ b/configure.ac
@@ -80,33 +80,51 @@ AC_PROG_INSTALL
 
 # argtable
 
-AC_CHECK_LIB(argtable2, arg_parse,  [], [argtable2_devel=notfound])
-if test "x$argtable2_devel" = "xnotfound"; then
-    AC_MSG_ERROR([argtable2-devel not found])
-fi
+AC_CHECK_HEADERS(
+    [argtable2.h],
+    [],
+    [AC_MSG_ERROR([argtable2 development headers not found])]
+)
+
+AC_CHECK_LIB(
+    [argtable2],
+    [arg_parse],
+    [],
+    [AC_MSG_ERROR([argtable2 library not found])]
+)
 
 # libz
 
-AC_CHECK_LIB(z, inflate,  [], [zlib_devel=notfound])
-if test "x$zlib_devel" = "xnotfound"; then
-    AC_MSG_ERROR([zlib-devel not found])
-fi
+AC_CHECK_HEADERS(
+    [zlib.h],
+    [],
+    [AC_MSG_ERROR([zlib development headers not found])]
+)
 
-# log from libm
+AC_CHECK_LIB(
+    [z],
+    [inflate],
+    [],
+    [AC_MSG_ERROR([zlib library not found])]
+)
 
-AC_SEARCH_LIBS([log], [m], [],
-  [AC_MSG_ERROR([log() not found
+# log() from libm
 
-msamtools requires a working floating-point math library.
-FAILED.  This error must be resolved in order to build msamtools successfully.])])
+AC_SEARCH_LIBS(
+    [log],
+    [m],
+    [],
+    [AC_MSG_ERROR([msamtools requires a working floating-point math library])]
+)
 
 # pthread for samtools
 
-AC_SEARCH_LIBS([pthread_create], [pthread], [],
-  [AC_MSG_ERROR([pthread_create() not found
-
-msamtools requires a working pthread library.
-FAILED.  This error must be resolved in order to build msamtools successfully.])])
+AC_SEARCH_LIBS(
+    [pthread_create],
+    [pthread],
+    [],
+    [AC_MSG_ERROR([msamtools requires a working pthread library])]
+)
 
 #######################################################
 # Figure out host type

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,12 @@ if test "x$GZIP" = "xnotfound"; then
     AC_MSG_ERROR([gzip not found in path])
 fi
 
+# Needed for samtools
+AC_CHECK_PROG([BZIP2], [bzip2], [found], [notfound])
+if test "x$BZIP2" = "xnotfound"; then
+    AC_MSG_ERROR([bzip2 not found in path])
+fi
+
 AC_CHECK_PROG([TAR], [tar], [found], [notfound])
 if test "x$TAR" = "xnotfound"; then
     AC_MSG_ERROR([tar not found in path])

--- a/configure.ac
+++ b/configure.ac
@@ -32,35 +32,36 @@ m4_pattern_allow([AM_PROG_AR])
 AM_PROG_AR
 
 #######################################################
-# programs for external file download and installation
+# Programs required for dependency download
 #######################################################
 
-# network download, uncompress etc
-
 AC_CHECK_PROG([GZIP], [gzip], [found], [notfound])
-if test "x$GZIP" = "xnotfound"; then
-    AC_MSG_ERROR([gzip not found in path])
-fi
+AS_IF(
+    [test "x$GZIP" = "xnotfound"],
+    [AC_MSG_ERROR([gzip not found in PATH])]
+)
 
-# Needed for samtools
 AC_CHECK_PROG([BZIP2], [bzip2], [found], [notfound])
-if test "x$BZIP2" = "xnotfound"; then
-    AC_MSG_ERROR([bzip2 not found in path])
-fi
+AS_IF(
+    [test "x$BZIP2" = "xnotfound"],
+    [AC_MSG_ERROR([bzip2 not found in PATH])]
+)
 
 AC_CHECK_PROG([TAR], [tar], [found], [notfound])
-if test "x$TAR" = "xnotfound"; then
-    AC_MSG_ERROR([tar not found in path])
-fi
+AS_IF(
+    [test "x$TAR" = "xnotfound"],
+    [AC_MSG_ERROR([tar not found in PATH])]
+)
 
 AC_CHECK_PROGS([WGET], [wget curl], [notfound])
-if test "x$WGET" = "xnotfound"; then
-    AC_MSG_ERROR([wget or curl not found in path])
-elif test "x$WGET" = "xcurl"; then
-    AC_SUBST([WGET_ARGS], ["--location --progress-bar -o -"])
-else
-    AC_SUBST([WGET_ARGS], ["--progress=dot:mega -O -"])
-fi
+AS_IF(
+    [test "x$WGET" = "xnotfound"],
+    [AC_MSG_ERROR([wget or curl not found in PATH])],
+    [test "x$WGET" = "xcurl"],
+    [WGET_ARGS="--location --progress-bar -o -"],
+    [WGET_ARGS="--progress=dot:mega -O -"]
+)
+AC_SUBST([WGET_ARGS])
 
 AC_ARG_VAR(BUILD, [Build ID for the programs])
 AC_SUBST(BUILD, [$BUILD])

--- a/configure.ac
+++ b/configure.ac
@@ -4,8 +4,7 @@
 
 
 AC_PREREQ(2.62)
-AC_REVISION([$Revision: 1.1 $])
-AC_COPYRIGHT()
+
 AC_INIT(
     [msamtools],
     [1.1.3],

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,6 @@
 #######################################################
-# Initialize autoconf/automake environment
+# Initialize Autoconf/Automake environment
 #######################################################
-
 
 AC_PREREQ([2.69])
 
@@ -19,11 +18,11 @@ AC_INIT(
 AC_CONFIG_AUX_DIR([build-aux])
 aux_files_dir=build-aux
 
-# automake
-
 AM_INIT_AUTOMAKE([1.16.5 -Wall foreign tar-pax subdir-objects])
 
-# Compilers etc
+#######################################################
+# Compilers and build tools
+#######################################################
 
 AC_PROG_CC
 AC_PROG_RANLIB
@@ -61,9 +60,6 @@ AS_IF(
     [WGET_ARGS="--progress=dot:mega -O -"]
 )
 AC_SUBST([WGET_ARGS])
-
-AC_ARG_VAR(BUILD, [Build ID for the programs])
-AC_SUBST(BUILD, [$BUILD])
 
 #######################################################
 # programs for installation

--- a/configure.ac
+++ b/configure.ac
@@ -21,15 +21,14 @@ aux_files_dir=build-aux
 
 # automake
 
-AM_INIT_AUTOMAKE([-Wall gnu foreign tar-pax subdir-objects])
+AM_INIT_AUTOMAKE([1.16.5 -Wall foreign tar-pax subdir-objects])
 
 # Compilers etc
 
 AC_PROG_CC
 AC_PROG_RANLIB
-AC_LANG([C])
-m4_pattern_allow([AM_PROG_AR])
 AM_PROG_AR
+AC_LANG([C])
 
 #######################################################
 # Programs required for dependency download
@@ -127,42 +126,34 @@ AC_SEARCH_LIBS(
 )
 
 #######################################################
-# Figure out host type
+# Host configuration
 #######################################################
-
-# We use AC_CANONICAL_HOST to figure it out.
-# It requires that we distribute config.guess, config.sub and install.sh with the distro.
 
 AC_CANONICAL_HOST
 
-AC_SUBST([MYCFLAGS], ["-W -Wall -Wwrite-strings -std=gnu99 -pedantic"])
+AC_SUBST(
+    [MYCFLAGS],
+    ["-Wall -Wextra -Wwrite-strings -std=gnu99 -pedantic"]
+)
 
 AC_SUBST([MACHINE_TYPE], [$host_cpu])
+
 kernel_name=`uname -s`
 AC_SUBST([KERNEL_NAME], [$kernel_name])
 
-#SOFTWAREDIR="$datarootdir"
-#AC_SUBST([SOFTWAREDIR], [$SOFTWAREDIR])
-
-#######################################################
-# user specified input through environmental variables
-#######################################################
-
-# substitutions
-
-# local directories
-
 AC_SUBST([HOST],    [generic])
+
 AC_SUBST([AUX_DIR], [$aux_files_dir])
 
 #######################################################
 # Make outputs
 #######################################################
 
-AC_CONFIG_FILES([Makefile])
-AC_CONFIG_FILES([deps/Makefile])
-AC_CONFIG_FILES([deps/samtools/Makefile])
-AS_IF([test -f "data/samtools/Makefile"], [rm data/samtools/Makefile])
+AC_CONFIG_FILES([
+    Makefile
+    deps/Makefile
+    deps/samtools/Makefile
+])
 
 AC_OUTPUT
 
@@ -177,11 +168,11 @@ msamtools was successfully configured with the following options:
    Host type          : $host
    Install directory  : $prefix
 
-You can build msamtools executables by typing:
+You can build msamtools by typing:
 
    make
 
-You can install msamtools now by typing:
+You can install msamtools by typing:
 
    make install
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,14 @@
 AC_PREREQ(2.62)
 AC_REVISION([$Revision: 1.1 $])
 AC_COPYRIGHT()
-AC_INIT([msamtools], [1.1.3], [http://arumugamlab.sund.ku.dk])
+AC_INIT(
+    [msamtools],
+    [1.1.3],
+    [https://github.com/arumugamlab/msamtools/issues],
+    [msamtools],
+    [https://github.com/arumugamlab/msamtools]
+)
+
 
 # we need the aux_dir for installing config.guess to bin/ later.
 # So store it in a variable now, and use AC_SUBST later

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 #######################################################
 
 
-AC_PREREQ(2.62)
+AC_PREREQ([2.69])
 
 AC_INIT(
     [msamtools],
@@ -13,22 +13,11 @@ AC_INIT(
     [https://github.com/arumugamlab/msamtools]
 )
 
-
 # we need the aux_dir for installing config.guess to bin/ later.
 # So store it in a variable now, and use AC_SUBST later
 
 AC_CONFIG_AUX_DIR([build-aux])
 aux_files_dir=build-aux
-
-#######################################################
-# Define missing things: macro definitions and such
-#######################################################
-
-# AS_VAR_APPEND
-
-dnl autoconf versions before 2.63b don't have AS_VAR_APPEND
-m4_ifdef([AS_VAR_APPEND],,[as_fn_append () { eval $[1]=\$$[1]\$[2]; }
-AC_DEFUN([AS_VAR_APPEND],[as_fn_append $1 $2])])dnl
 
 # automake
 

--- a/deps/samtools/defs.txt
+++ b/deps/samtools/defs.txt
@@ -1,5 +1,5 @@
-tar_file := samtools-${samtools_version}.tar.bz2
-download_url := https://github.com/samtools/samtools/releases/download/${samtools_version}/$(tar_file)
+tar_file = samtools-$(samtools_version).tar.bz2
+download_url = https://github.com/samtools/samtools/releases/download/$(samtools_version)/$(tar_file)
 package_zip_format = bzip2
-unpack_dir := samtools-${samtools_version}
+unpack_dir = samtools-$(samtools_version)
 config_options = --disable-lzma --disable-bz2 --disable-s3 --disable-gcs --disable-libcurl --disable-plugins --without-curses

--- a/zoe-LICENSE
+++ b/zoe-LICENSE
@@ -1,0 +1,22 @@
+Copyright (C) Ian Korf 2002-2013.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+The MIT License (MIT) - opensource.org/licenses/MIT

--- a/zoeTools.c
+++ b/zoeTools.c
@@ -1,21 +1,28 @@
 /******************************************************************************\
  zoeTools.c - part of the ZOE library for genomic analysis
  
-Copyright (C) 2002-2005 Ian Korf
+Copyright (C) Ian Korf 2002-2013.
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
 
-You should have received a copy of the GNU General Public License
-along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+The MIT License (MIT) - opensource.org/licenses/MIT
 
 \******************************************************************************/
 
@@ -28,7 +35,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  Library Information
 \******************************************************************************/
 
-static char zoeVersionNumber[] = "2006-07-28";
+static char zoeVersionNumber[] = "2017-03-01";
 
 void zoeLibInfo (void) {
 	zoeS(stderr, "ZOE library version %s\n", zoeVersionNumber);
@@ -176,11 +183,6 @@ void zoePushVec (zoeVec vec, void * thing) {
 	vec->last = vec->elem[vec->size];
 	vec->size++;
 }
-
-int zoeTcmp (const void * a, const void * b) {
-	return strcmp( *(char **)a, *(char **)b );
-}
-
 
 /******************************************************************************\
  Generic Hash

--- a/zoeTools.h
+++ b/zoeTools.h
@@ -1,7 +1,28 @@
 /******************************************************************************\
  zoeTools.h - part of the ZOE library for genomic analysis
  
- Copyright (C) 2002-2005 Ian Korf
+Copyright (C) Ian Korf 2002-2013.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+The MIT License (MIT) - opensource.org/licenses/MIT
 
 \******************************************************************************/
 
@@ -41,7 +62,6 @@ typedef struct zoeTVec * zoeTVec;
 void    zoeDeleteTVec (zoeTVec);
 zoeTVec zoeNewTVec (void);
 void    zoePushTVec (zoeTVec, const char *);
-int zoeTcmp (const void * a, const void * b);
 
 struct zoeVec  {
 	void ** elem;


### PR DESCRIPTION
This PR:
- modernizes Autotools configuration;
- installs third-party license notices with msamtools;
- re-derives ZOE utility code from the MIT-licensed SNAP source;
- improves licensing provenance for binary distributions.