### PR TITLE
Modernize Dockerfile and add local tarball build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,85 @@
+################## BUILDING NOTES ######################
+#
+# Build from the published GitHub release (default):
+#   docker build -t msamtools:1.1.3 .
+#
+# Build from a local release tarball for testing:
+#   Place msamtools-<version>.tar.gz in the build context, then run:
+#   docker build --build-arg MSAM_SOURCE=local --build-arg MSAM_VERSION=<version> -t msamtools:test .
+#
+# MSAM_SOURCE may be "remote" (default) or "local".
+
+################## BUILD ARGUMENTS ######################
+ARG MSAM_VERSION=1.1.3
+ARG MSAM_SOURCE=remote
+
+################## REMOTE SOURCE ######################
+FROM alpine:3.23 AS source-remote
+
+ARG MSAM_VERSION
+
+RUN apk add --no-cache wget \
+    && wget \
+        "https://github.com/arumugamlab/msamtools/releases/download/${MSAM_VERSION}/msamtools-${MSAM_VERSION}.tar.gz" \
+        -O /msamtools.tar.gz
+
+
+################## LOCAL SOURCE ######################
+FROM scratch AS source-local
+
+ARG MSAM_VERSION
+
+COPY msamtools-${MSAM_VERSION}.tar.gz /msamtools.tar.gz
+
+
+################## SELECT SOURCE ######################
+ARG MSAM_SOURCE
+FROM source-${MSAM_SOURCE} AS source
+
+
 ################## BASE IMAGE ######################
 FROM alpine:3.23
+
+ARG MSAM_VERSION
 
 ################## METADATA ######################
 LABEL base_image="alpine:3.23"
 LABEL version="1"
 LABEL software="msamtools"
-LABEL software.version="1.1.3"
+LABEL software.version="${MSAM_VERSION}"
 LABEL about.summary="microbiome-related extension to samtools"
 LABEL about.home="https://github.com/arumugamlab/msamtools"
 LABEL about.documentation="https://github.com/arumugamlab/msamtools"
-LABEL about.license_file="https://github.com/arumugamlab/msamtools"
+LABEL about.license_file="https://github.com/arumugamlab/msamtools/blob/master/LICENSE"
 LABEL about.license="SPDX:MIT"
 LABEL about.tags="Metagenomics, Genomics"
 LABEL extra.identifiers.biotools="msamtools"
 LABEL org.opencontainers.image.authors="arumugam@sund.ku.dk"
 
-################## MAINTAINER ######################
-MAINTAINER Mani Arumugam <arumugam@sund.ku.dk>
-
 ################## INSTALLATION ######################
 
-ENV MSAM_VERSION 1.1.3
+ENV MSAM_VERSION=${MSAM_VERSION}
+
+COPY --from=source /msamtools.tar.gz /tmp/msamtools.tar.gz
 
 RUN apk --no-cache update \
     && apk --no-cache upgrade \
     && apk add --no-cache argtable2 \
-    && apk add --no-cache --virtual .build_deps gcc libc-dev wget zlib-dev make bash argtable2-dev \
+    && apk add --no-cache --virtual .build_deps \
+        gcc \
+        libc-dev \
+        zlib-dev \
+        make \
+        bash \
+        argtable2-dev \
     && cd /tmp \
-    && wget https://github.com/arumugamlab/msamtools/releases/download/$MSAM_VERSION/msamtools-$MSAM_VERSION.tar.gz -O - | tar xfz - \
-    && cd msamtools-$MSAM_VERSION/ \
+    && tar xfz msamtools.tar.gz \
+    && cd "msamtools-${MSAM_VERSION}" \
     && ./configure --prefix=/usr \
     && make install \
     && /usr/bin/install -c deps/samtools/samtools-1.9/samtools /usr/bin \
     && cd /tmp \
-    && rm -rf msamtools-$MSAM_VERSION \
+    && rm -rf "msamtools-${MSAM_VERSION}" msamtools.tar.gz \
     && apk del .build_deps
 
 ENTRYPOINT ["msamtools"]

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,11 @@
 # Third-party software
 
-msamtools uses third-party components from **samtools** and **HTSlib**.
+msamtools uses third-party components from **samtools**, **HTSlib** and **ZOE/SNAP**.
+
+The msamtools source distribution bundles modified versions of two files
+from ZOE source code. The upstream license text is distributed as well as
+installed alongside msamtools as:
+- `zoe-LICENSE`
 
 The msamtools source distribution does **not** bundle the samtools or HTSlib
 source code. During the build process, the required upstream versions are

--- a/configure.ac
+++ b/configure.ac
@@ -55,8 +55,8 @@ AS_IF(
     [test "x$WGET" = "xnotfound"],
     [AC_MSG_ERROR([wget or curl not found in PATH])],
     [test "x$WGET" = "xcurl"],
-    [WGET_ARGS="--location --progress-bar -o -"],
-    [WGET_ARGS="--progress=dot:mega -O -"]
+    [WGET_ARGS="--location --silent"],
+    [WGET_ARGS="-q -O -"]
 )
 AC_SUBST([WGET_ARGS])
 


### PR DESCRIPTION
This PR updates the msamtools Dockerfile and adds support for building from a local release tarball.

Changes include:

- parameterizing the msamtools version
- retaining the published GitHub release as the default build source
- adding `MSAM_SOURCE=local` for testing unreleased release tarballs
- using a multi-stage build to keep local and remote source handling separate
- updating metadata handling and removing the deprecated `MAINTAINER` instruction
- pointing the license metadata to the project license file
- adding concise build instructions for maintainers

The local-source build has been tested successfully using a generated msamtools release tarball. The normal remote-source path can be smoke-tested again after the next release asset is published.