### PR TITLE
Fixed multi-mapper insert counts in reports (profiles mostly unaffected)

### DIFF
--- a/msam_profile.c
+++ b/msam_profile.c
@@ -126,11 +126,6 @@ void mEstimateInsertCountOnPool(mBamPool *pool, int share_type) {
 		}
 
 		default:
-			global->multi_mapper_count++;
-			if (share_type == MULTI_IGNORE) {
-				break;
-			}
-
 		{
 			uint8_t  *ub_target_hit = global->ub_target_hit;
 			mIVector *mappers = (mIVector*) mMalloc(sizeof(mIVector)); /* Will be freed by main */
@@ -145,8 +140,31 @@ void mEstimateInsertCountOnPool(mBamPool *pool, int share_type) {
 				}
 			}
 
+			/* Reset target_hit flags to 0 */
+			for (i=0; i<mappers->size; i++) ub_target_hit[mappers->elem[i]] = 0;
+
+			/*
+			 * Multiple alignments can correspond to repeated loci within the
+			 * same profiled feature. In that case the insert is unambiguous
+			 * at the profiling level and should be counted once as unique.
+			 */
+			if (mappers->size == 1) {
+				global->ui_insert_count[mappers->elem[0]] += 2;
+				global->uniq_mapper_count++;
+
+				mFreeIVector(mappers);
+				mFree(mappers);
+				return;
+			}
+
+			/* More than one distinct feature: true multi-mapper. */
+			global->multi_mapper_count++;
+
 			/* Share or add the value 1 (for d_insert_count) or 2 (for ui_insert_count) across all mappers depending on the share type */
 			switch(share_type) {
+				case MULTI_IGNORE:
+					break;
+
 				case MULTI_ADD_ALL:
 					for (i=0; i<mappers->size; i++) {
 						global->ui_insert_count[mappers->elem[i]] += 2;
@@ -170,9 +188,6 @@ void mEstimateInsertCountOnPool(mBamPool *pool, int share_type) {
 					mDie("Do not understand share_type=%d", share_type);
 					break;
 			}
-
-			/* Reset target_hit flags to 0 */
-			for (i=0; i<mappers->size; i++) ub_target_hit[mappers->elem[i]] = 0;
 
 			/* Free mappers IVector */
 			if (share_type != MULTI_SHARE_PROPORTIONAL) { /* For MULTI_SHARE_PROPORTIONAL, will be freed by main */


### PR DESCRIPTION
Fixed `msamtools profile` classification of uniquely and multiply mapped inserts and the reported numbers in the output file in the format:
```
# Total inserts       : 100000 (100.00%)
# Mapped inserts      : 100000 (100.00%)
#   - Multiple mapped :   4474 (  4.47%)
#   - Uniquely mapped :  95526 ( 95.53%)
```

Previously, inserts with multiple alignments to different loci of the **same profiled feature** were counted as multi-mapped based on the number of SAM alignments in the query-name group. The abundance calculation already collapsed these alignments to unique feature IDs, so abundance profiles were accurate (except for `--multi ignore` -- see below). But the reported unique/multi-mapped were counts inconsistent with the actual profiling behavior.

> [!IMPORTANT]
For `--multi ignore`, such inserts could also be discarded unnecessarily, thus affecting the abundance profile. If you have used `--multi ignore` in your analysis, you may want to recompute the profiles.

This change determines the distinct profiled feature IDs first and then classifies the insert:

* one distinct feature → uniquely mapped
* multiple distinct features → multi-mapped

The existing multi-mapper sharing behavior is otherwise unchanged.

The fix was validated using synthetic paired-end alignments containing both repeated mappings within a genome and genuine cross-genome multimappers.