### PR TITLE
Upgrade HTSlib dependency to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,11 @@ RUN apk --no-cache update \
         --disable-lzma \
         --disable-libcurl \
         --without-libdeflate \
+        --disable-lzma \
+        --disable-s3 \
+        --disable-gcs \
+        --disable-plugins \
+        --disable-ref-cache \
     && make samtools \
     && /usr/bin/install -c samtools /usr/bin/samtools \
     && /usr/bin/install -c -m0644 LICENSE /usr/share/licenses/msamtools/samtools-LICENSE \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM alpine:3.23 AS source-remote
 ARG MSAM_VERSION
 
 RUN apk add --no-cache wget \
-    && wget \
+    && wget -q \
         "https://github.com/arumugamlab/msamtools/releases/download/${MSAM_VERSION}/msamtools-${MSAM_VERSION}.tar.gz" \
         -O /msamtools.tar.gz
 
@@ -71,15 +71,37 @@ RUN apk --no-cache update \
         zlib-dev \
         make \
         bash \
+        wget \
+        bzip2 \
         argtable2-dev \
     && cd /tmp \
     && tar xfz msamtools.tar.gz \
     && cd "msamtools-${MSAM_VERSION}" \
+    && HTSLIB_VERSION="$(awk '$1 == "htslib_version" {print $3}' versions.txt)" \
+    && test -n "${HTSLIB_VERSION}" \
     && ./configure --prefix=/usr \
     && make install \
-    && /usr/bin/install -c deps/samtools/samtools-1.9/samtools /usr/bin \
     && cd /tmp \
-    && rm -rf "msamtools-${MSAM_VERSION}" msamtools.tar.gz \
+    && wget -q \
+        "https://github.com/samtools/samtools/releases/download/${HTSLIB_VERSION}/samtools-${HTSLIB_VERSION}.tar.bz2" \
+        -O samtools.tar.bz2 \
+    && tar xjf samtools.tar.bz2 \
+    && cd "samtools-${HTSLIB_VERSION}" \
+    && ./configure \
+        --without-curses \
+        --disable-bz2 \
+        --disable-lzma \
+        --disable-libcurl \
+        --without-libdeflate \
+    && make samtools \
+    && /usr/bin/install -c samtools /usr/bin/samtools \
+    && /usr/bin/install -c -m0644 LICENSE /usr/share/licenses/msamtools/samtools-LICENSE \
+    && cd /tmp \
+    && rm -rf \
+        "msamtools-${MSAM_VERSION}" \
+        "samtools-${HTSLIB_VERSION}" \
+        msamtools.tar.gz \
+        samtools.tar.bz2 \
     && apk del .build_deps
 
 ENTRYPOINT ["msamtools"]

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,36 @@
 # Version info
 include versions.txt
 
+# Git provenance
+BUILT_SOURCES = msam_version.h
+
+.PHONY: FORCE
+msam_version.h: FORCE
+	@set -e; \
+	if git -C "$(srcdir)" rev-parse --git-dir >/dev/null 2>&1; then \
+		commit=`git -C "$(srcdir)" rev-parse --short=12 HEAD`; \
+		printf '%s\n' \
+			'#ifndef MSAM_VERSION_H' \
+			'#define MSAM_VERSION_H' \
+			"#define MSAM_GIT_COMMIT \"$$commit\"" \
+			'#endif' > $@.tmp; \
+	elif test -f "$(srcdir)/msam_version.h"; then \
+		cat "$(srcdir)/msam_version.h" > $@.tmp; \
+	else \
+		printf '%s\n' \
+			'#ifndef MSAM_VERSION_H' \
+			'#define MSAM_VERSION_H' \
+			'#define MSAM_GIT_COMMIT "unknown"' \
+			'#endif' > $@.tmp; \
+	fi; \
+	if test -f $@ && cmp -s $@.tmp $@; then \
+		rm -f $@.tmp; \
+	else \
+		mv -f $@.tmp $@; \
+	fi
+
+FORCE:
+
 # We need htslib dependencies to be built first
 SUBDIRS = deps
 
@@ -32,6 +62,19 @@ uninstall-hook:
 	rm -f \
 		"$(DESTDIR)$(licensedir)/htslib-LICENSE"
 	-rmdir "$(DESTDIR)$(licensedir)"
+
+dist-hook:
+	@git -C "$(srcdir)" diff --quiet && \
+	 git -C "$(srcdir)" diff --cached --quiet || { \
+		echo "ERROR: refusing to create distribution from a dirty Git tree"; \
+		exit 1; \
+	}
+	@commit=`git -C "$(srcdir)" rev-parse --short=12 HEAD` || exit 1; \
+	printf '%s\n' \
+		'#ifndef MSAM_VERSION_H' \
+		'#define MSAM_VERSION_H' \
+		"#define MSAM_GIT_COMMIT \"$$commit\"" \
+		'#endif' > "$(distdir)/msam_version.h"
 
 # Where to install the programs
 mymauidir = $(bindir)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 # Version info
 include versions.txt
 
-# We need samtools dependencies to be built first
+# We need htslib dependencies to be built first
 SUBDIRS = deps
 
 # These are the installed programs
@@ -20,20 +20,16 @@ license_DATA = LICENSE \
                THIRD_PARTY_NOTICES.md
 
 # Install licenses for third-party code incorporated during the build.
-# samtools and HTSlib are downloaded into the build tree by the
+# HTSlib is downloaded into the build tree by the
 # dependency build machinery and are therefore not part of EXTRA_DIST.
 install-data-hook:
 	$(MKDIR_P) "$(DESTDIR)$(licensedir)"
 	$(INSTALL_DATA) \
-		"$(builddir)/deps/samtools/samtools-$(samtools_version)/LICENSE" \
-		"$(DESTDIR)$(licensedir)/samtools-LICENSE"
-	$(INSTALL_DATA) \
-		"$(builddir)/deps/samtools/samtools-$(samtools_version)/htslib-$(samtools_version)/LICENSE" \
+		"$(builddir)/deps/htslib/htslib-$(htslib_version)/LICENSE" \
 		"$(DESTDIR)$(licensedir)/htslib-LICENSE"
 
 uninstall-hook:
 	rm -f \
-		"$(DESTDIR)$(licensedir)/samtools-LICENSE" \
 		"$(DESTDIR)$(licensedir)/htslib-LICENSE"
 	-rmdir "$(DESTDIR)$(licensedir)"
 
@@ -61,15 +57,15 @@ dist_libmaui_a_SOURCES = $(srcdir)/mCommon.c \
 
 # Specify CFLAGS and LDFLAGS
 
+ARFLAGS = cr
+
 AM_CFLAGS = $(MYCFLAGS) \
             -DPROGRAM=\"msamtools\" \
-            -DHTSLIB_VERSION=\"$(samtools_version)\" \
-            -I$(builddir)/deps/samtools/samtools-$(samtools_version)/htslib-$(samtools_version) \
-            -I$(builddir)/deps/samtools/samtools-$(samtools_version)
+            -DHTSLIB_VERSION=\"$(htslib_version)\" \
+            -I$(builddir)/deps/htslib/htslib-$(htslib_version)
 
 LDADD = $(builddir)/libmaui.a \
-        $(builddir)/deps/samtools/samtools-$(samtools_version)/libbam.a \
-        $(builddir)/deps/samtools/samtools-$(samtools_version)/htslib-$(samtools_version)/libhts.a
+        $(builddir)/deps/htslib/htslib-$(htslib_version)/libhts.a
 
 clean-local:
 	for file in libmaui.a; do \

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,21 +1,18 @@
 # Third-party software
 
-msamtools uses third-party components from **samtools**, **HTSlib** and **ZOE/SNAP**.
+msamtools uses third-party components from **HTSlib** and **ZOE/SNAP**.
 
 The msamtools source distribution bundles modified versions of two files
 from ZOE source code. The upstream license text is distributed as well as
 installed alongside msamtools as:
+
 - `zoe-LICENSE`
 
-The msamtools source distribution does **not** bundle the samtools or HTSlib
-source code. During the build process, the required upstream versions are
-downloaded and used to build msamtools.
+The msamtools source distribution does **not** bundle HTSlib source code.
+During the build process, the required upstream HTSlib version is downloaded
+and statically linked into the msamtools executable. The corresponding
+upstream license text is installed alongside msamtools as:
 
-Binary distributions of msamtools may therefore contain code derived from or
-statically linked with samtools and HTSlib. For such distributions, the
-corresponding upstream license texts are installed alongside msamtools as:
-
-- `samtools-LICENSE`
 - `htslib-LICENSE`
 
 These files are installed together with:
@@ -27,32 +24,40 @@ typically under:
 
 - `share/licenses/msamtools/`
 
-The msamtools Docker image additionally includes the `samtools` executable.
-Its license is covered by the accompanying `samtools-LICENSE` file.
+The msamtools Docker image additionally includes the **samtools** executable.
+Samtools is not used to build or link the msamtools executable. The Docker
+image uses the samtools release corresponding to the HTSlib version used by
+msamtools. Its license is provided as:
 
-## samtools (v1.9)
+- `samtools-LICENSE`
 
-samtools is developed by Genome Research Ltd. and the samtools authors and
-contributors.
-
-samtools is available at
-[https://github.com/samtools/samtools](https://github.com/samtools/samtools)
-and distributed under the MIT/Expat License.
-
-The complete copyright and license notice for the version used to build
-msamtools is provided in `samtools-LICENSE`.
-
-## HTSlib (v1.9)
+## HTSlib (v1.24)
 
 HTSlib is developed by Genome Research Ltd. and the HTSlib authors and
 contributors.
 
 HTSlib is available at
 [https://github.com/samtools/htslib](https://github.com/samtools/htslib)
-distributed under the MIT/Expat License.
+and distributed under the MIT/Expat License.
 
+HTSlib is downloaded at build time and statically linked into msamtools.
 The complete copyright and license notice for the version used to build
 msamtools is provided in `htslib-LICENSE`.
+
+## samtools (v1.24; Docker image only)
+
+Samtools is developed by Genome Research Ltd. and the samtools authors and
+contributors.
+
+Samtools is available at
+[https://github.com/samtools/samtools](https://github.com/samtools/samtools)
+and distributed under the MIT/Expat License.
+
+Samtools is not a build or API dependency of msamtools. The msamtools Docker
+image additionally distributes the samtools executable for user convenience.
+The Docker image uses the samtools release corresponding to the HTSlib version
+used by msamtools. Its complete copyright and license notice is provided in
+`samtools-LICENSE`.
 
 ## ZOE / SNAP
 

--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ AC_SEARCH_LIBS(
     [AC_MSG_ERROR([msamtools requires a working floating-point math library])]
 )
 
-# pthread for samtools
+# pthread for htslib
 
 AC_SEARCH_LIBS(
     [pthread_create],
@@ -147,7 +147,7 @@ AC_SUBST([AUX_DIR], [$aux_files_dir])
 AC_CONFIG_FILES([
     Makefile
     deps/Makefile
-    deps/samtools/Makefile
+    deps/htslib/Makefile
 ])
 
 AC_OUTPUT

--- a/deps/Makefile.am
+++ b/deps/Makefile.am
@@ -1,2 +1,2 @@
-DIST_SUBDIRS = samtools
-SUBDIRS = samtools
+DIST_SUBDIRS = htslib
+SUBDIRS = htslib

--- a/deps/Makefile.inc
+++ b/deps/Makefile.inc
@@ -12,7 +12,7 @@ all-local: $(dep_complete)
 
 $(dep_complete): $(untar_complete)
 	@echo "Building $(software)"
-	@cd $(unpack_dir) && if [ -f "./configure" ]; then ./configure $(config_options); fi && $(MAKE)
+	@cd $(unpack_dir) && if [ -f "./configure" ]; then ./configure $(config_options); fi && $(MAKE) $(make_target)
 	@touch $(dep_complete)
 
 $(untar_complete): $(tar_file)

--- a/deps/htslib/Makefile.am
+++ b/deps/htslib/Makefile.am
@@ -2,12 +2,12 @@
 
 # software information
 
-software = samtools
-library_file = libbam.a libhts.a
+software = htslib
+library_file = libhts.a
 
 include ../../versions.txt
 include defs.txt
 
-dep_files = $(unpack_dir)/libbam.a $(unpack_dir)/htslib-${samtools_version}/libhts.a
+dep_files = $(unpack_dir)/libhts.a
 
 include ../Makefile.inc

--- a/deps/htslib/defs.txt
+++ b/deps/htslib/defs.txt
@@ -1,0 +1,6 @@
+tar_file = htslib-$(htslib_version).tar.bz2
+download_url = https://github.com/samtools/htslib/releases/download/$(htslib_version)/$(tar_file)
+package_zip_format = bzip2
+unpack_dir = htslib-$(htslib_version)
+config_options = --disable-lzma --disable-bz2 --disable-s3 --disable-gcs --disable-libcurl --disable-plugins --disable-ref-cache
+make_target = lib-static

--- a/deps/samtools/defs.txt
+++ b/deps/samtools/defs.txt
@@ -1,5 +1,0 @@
-tar_file = samtools-$(samtools_version).tar.bz2
-download_url = https://github.com/samtools/samtools/releases/download/$(samtools_version)/$(tar_file)
-package_zip_format = bzip2
-unpack_dir = samtools-$(samtools_version)
-config_options = --disable-lzma --disable-bz2 --disable-s3 --disable-gcs --disable-libcurl --disable-plugins --without-curses

--- a/mBamVector.c
+++ b/mBamVector.c
@@ -1,3 +1,4 @@
+#include "msam.h"
 #include "mBamVector.h"
 
 /* Generic BAM/SAM utilities */
@@ -23,7 +24,7 @@ int32_t bam_highquality_differences_only(const bam1_t *b, uint8_t minqual) {
 
 	/* Get quality */
 
-	uint8_t *q   = bam1_qual(b);
+	uint8_t *q   = bam_get_qual(b);
 
 	/* get MD values */
 
@@ -103,7 +104,7 @@ void bam_cigar2details(const bam1_core_t *c, const uint32_t *cigar, int32_t *ale
 void bam_get_summary(const bam1_t *b, mAlignmentSummary *summary) {
 
 	bam1_core_t *c     = (bam1_core_t*) &b->core;
-	uint32_t    *cigar = bam1_cigar(b);
+	uint32_t    *cigar = bam_get_cigar(b);
 
 	/* MD stuff */
 
@@ -194,7 +195,7 @@ void bam_get_summary(const bam1_t *b, mAlignmentSummary *summary) {
 void bam_get_extended_summary(const bam1_t *b, mAlignmentSummary *summary) {
 
 	bam1_core_t *c     = (bam1_core_t*) &b->core;
-	uint32_t    *cigar = bam1_cigar(b);
+	uint32_t    *cigar = bam_get_cigar(b);
 
 	/* MD stuff */
 
@@ -328,12 +329,12 @@ void mEmptyBamVector(mBamVector *vec) {
 	vec->size = 0;
 }
 
-void mWriteBamVector(samfile_t *stream, mBamVector *bamvector) {
+void mWriteBamVector(mSamFile *stream, mBamVector *bamvector) {
 	int i;
 	for (i=0; i<bamvector->size; i++) {
 		bam1_t *b = bamvector->elem[i];
 		if (b != NULL) {
-			samwrite(stream, b);
+			mSamWrite(stream, b);
 		}
 	}
 }
@@ -373,7 +374,9 @@ void mReOriginateBamPool(mBamPool *pool) {
 	if (pool->size == 0) {
 		return;
 	}
-	bam_copy1(pool->elem[0], pool->elem[pool->size]);
+	if (bam_copy1(pool->elem[0], pool->elem[pool->size]) == NULL)
+		mDie("Failed to copy BAM alignment");
+
 	pool->size = 0;
 }
 
@@ -395,10 +398,10 @@ void mFreeBamPool(mBamPool *pool) {
 	mFree(pool->elem);
 }
 
-void mWriteBamPool(samfile_t *stream, mBamPool *pool) {
+void mWriteBamPool(mSamFile *stream, mBamPool *pool) {
 	int i;
 	bam1_t **elem = pool->elem;
 	for (i=0; i<pool->size; i++) 
-		samwrite(stream, elem[i]);
+		mSamWrite(stream, elem[i]);
 }
 

--- a/mBamVector.h
+++ b/mBamVector.h
@@ -1,7 +1,6 @@
 #include <inttypes.h>
 #include "mCommon.h"
-#include "bam.h"
-#include "sam.h"
+#include <htslib/sam.h>
 #include "htslib/kstring.h"
 
 /*
@@ -21,7 +20,7 @@
  *              I leave the function for backward compatibility, but it is the 
  *              same as comparing full QNAMEs.
  */
-#define bam1_templatecmp(a,b) (strcmp(bam1_qname(a), bam1_qname(b)))
+#define bam1_templatecmp(a,b) (strcmp(bam_get_qname(a), bam_get_qname(b)))
 
 #define M_BAM_FOUTIE   2048
 #define M_BAM_FUNIDIR  4096
@@ -72,7 +71,7 @@ void mExpandBamVector(mBamVector *vec);
 void mFreeBamVector(mBamVector *vec);
 void mEmptyBamVector(mBamVector *vec);
 void mSortBamVector(mBamVector *vec, int(*compar)(const void *, const void *));
-void mWriteBamVector(samfile_t *stream, mBamVector *bamvector);
+void mWriteBamVector(mSamFile *stream, mBamVector *bamvector);
 
 /*
  *
@@ -94,4 +93,4 @@ void mExpandBamPool(mBamPool *pool);
 void mFreeBamPool(mBamPool *pool);
 bam1_t* mAdvanceBamPool(mBamPool *pool);
 void mReOriginateBamPool(mBamPool *pool);
-void mWriteBamPool(samfile_t *stream, mBamPool *pool);
+void mWriteBamPool(mSamFile *stream, mBamPool *pool);

--- a/msam.h
+++ b/msam.h
@@ -6,9 +6,7 @@
 #include <regex.h>
 #include <zlib.h>
 #include "argtable2.h"
-#include "bam.h"
-#include "sam.h"
-#include "mBamVector.h"
+#include <htslib/sam.h>
 #include "mMatrix.h"
 #include "zoeTools.h"
 
@@ -16,11 +14,13 @@
 typedef int coverage_t;
 #define COVERAGE_T_FORMAT "%d"
 
+/* global variables grouped into an object */
+
 struct msam_global {
 	int            multiple_input;
 
 	/* features to count vs sequences in bam file */
-	bam_header_t  *header;
+	sam_hdr_t     *header;
 	int           *fmap; /* feature map: seq-->feature*/
 	int            n_features;
 	uint32_t      *feature_len;
@@ -49,13 +49,26 @@ struct msam_global {
 };
 typedef struct msam_global msam_global;
 
-/* global variables grouped into an object */
-
 extern msam_global *global;
+
+/* New wrapper struct to replace old samfile_t */
+
+typedef struct {
+	samFile   *file;
+	sam_hdr_t *header;
+} mSamFile;
+
+/* Wrapper functions for mSamFile */
+
+mSamFile* mOpenSamInput(const char *filename, const char *inmode);
+mSamFile* mOpenSamOutput(const char *filename, const char *outmode,
+                         const sam_hdr_t *header);
+int       mSamRead(mSamFile *input, bam1_t *b);
+int       mSamWrite(mSamFile *output, bam1_t *b);
+int       mSamClose(mSamFile *stream);
 
 /* Helper functions */
 
-samfile_t* mOpenSamFile(const char *filename, const char *inmode, char *headerfile);
 void       mMultipleFileError(const char *subprogram, void **argtable);
 int        mHeaderCheck(int count, const char* filenames[], const char *inmode);
 

--- a/msam_coverage.c
+++ b/msam_coverage.c
@@ -1,16 +1,14 @@
 #include "msam.h"
+#include "mBamVector.h"
 
 /*
- * Note: samtools' bam_calend() function returns a 1-based coordinate instead of
- * a 0-based coordinate that the documentation promises. This is potentially 
- * because they want to easily estimate 
- *	len = end - beg;
+ * Note: bam_endpos() returns the 0-based exclusive end coordinate,
+ * i.e. the coordinate of the first reference base after the alignment.
+ * Therefore the covered interval is [start, end), and coverage is updated in mUpdateCoverageForAlignment() as:
  *
- * Therefore, the interpretation of bam_calend is not exactly as reported in 
- * 	http://samtools.sourceforge.net/samtools/bam/Functions/Functions.html#//apple_ref/c/func/bam_calend
+ *	for (i=start; i<end; i++)
  *
- * This is why the loop in mUpdateCoverageForAlignment() below goes
- *	(i=start; i<end; i++)
+ * This is equivalent to the behavior of the old samtools bam_calend().
  */
 
 void mInitCoverage() {
@@ -37,10 +35,10 @@ void mFreeCoverage() {
 }
 
 void mUpdateCoverageForAlignment(bam1_t *bam, coverage_t in_coverage) {
-	int i;
-	int tid   = bam->core.tid;
-	int start = bam->core.pos;
-	int end   = bam_calend(&bam->core, bam1_cigar(bam));
+	int tid         = bam->core.tid;
+	hts_pos_t start = bam->core.pos;
+	hts_pos_t end   = bam_endpos(bam);
+	hts_pos_t i;
 
 	int         *covered  = global->covered;
 	coverage_t **coverage = global->coverage;
@@ -48,15 +46,15 @@ void mUpdateCoverageForAlignment(bam1_t *bam, coverage_t in_coverage) {
 
 #ifdef DEBUG
 	fprintf(stderr, "Tagging target %d (%s) with %f: from %d to %d\n", tid, header->target_name[tid], in_coverage, start, end);
-	fprintf(stderr, "This tag was %d query bases long\n", bam_cigar2qlen(&bam->core, bam1_cigar(bam)));
+	fprintf(stderr, "This tag was %d query bases long\n", bam_cigar2qlen(&bam->core, bam_get_cigar(bam)));
 #endif
 
 	/* Why check before you write? Read takes less time than write, and write happens only n_targets times MAX */
 
 	if (covered[tid] == 0) {
-		int tlen      = global->header->target_len[tid];
-		covered[tid]  = 1; 
-		coverage[tid] = (coverage_t*) mCalloc(tlen, sizeof(coverage_t));
+		hts_pos_t tlen = global->header->target_len[tid];
+		covered[tid]   = 1; 
+		coverage[tid]  = (coverage_t*) mCalloc(tlen, sizeof(coverage_t));
 	}
 
 	/* It's important to assign this_coverage after the previous conditional clause.
@@ -87,7 +85,7 @@ void mEstimateCoverageOnPool(mBamPool *pool) {
 	}
 }
 
-void mEstimateCoverageOnFile(samfile_t *input) {
+void mEstimateCoverageOnFile(mSamFile *input) {
 
 	int       pool_limit = 64;
 	bam1_t   *current;
@@ -103,9 +101,9 @@ void mEstimateCoverageOnFile(samfile_t *input) {
 	current = pool_current(pool);
 
 	prev_read[0] = '\0';
-	while (samread(input, current) >= 0) {
+	while (mSamRead(input, current) >= 0) {
 		if ( (prev_read[0] != '\0') && 
-		     ((strcmp(bam1_qname(current), prev_read) != 0) || 
+		     ((strcmp(bam_get_qname(current), prev_read) != 0) || 
 		      (((current->core.flag | prev_flag) & mutual_pairs) == mutual_pairs)
 		     )
 		   ) {
@@ -114,7 +112,7 @@ void mEstimateCoverageOnFile(samfile_t *input) {
 			current = pool_current(pool);
 		}
 		prev_flag = current->core.flag;
-		strncpy(prev_read, bam1_qname(current), 127);
+		strncpy(prev_read, bam_get_qname(current), 127);
 		current   = mAdvanceBamPool(pool);
 	}
 	mEstimateCoverageOnPool(pool);
@@ -132,9 +130,8 @@ void mWriteCoverageToStream(gzFile stream, int skip_uncovered, int wordsize) {
 	coverage_t **coverage = global->coverage;
 
 	for (tid=0; tid<n_targets; tid++) {
-		int32_t    i;
-		/* coverage_t sum  = 0; */
-		int32_t    tlen = global->header->target_len[tid];
+		hts_pos_t    i;
+		hts_pos_t    tlen = global->header->target_len[tid];
 
 		/* If this target is not covered, deal with it */
 
@@ -162,7 +159,6 @@ void mWriteCoverageToStream(gzFile stream, int skip_uncovered, int wordsize) {
 		gzprintf(stream, ">%s\n", global->header->target_name[tid]);
 		for (i=0; i<tlen-1; i++) {
 			coverage_t val = coverage[tid][i];
-			/*sum += val; */
 			if ((i+1)%wordsize == 0) {
 				gzprintf(stream, COVERAGE_T_FORMAT"\n", val);
 			} else {
@@ -170,7 +166,6 @@ void mWriteCoverageToStream(gzFile stream, int skip_uncovered, int wordsize) {
 			}
 		}
 		gzprintf(stream, COVERAGE_T_FORMAT"\n", coverage[tid][tlen-1]);
-		/*fprintf(stderr, "%s\t%f\n", global->header->target_name[tid], sum/tlen);*/
 	}
 }
 
@@ -181,10 +176,10 @@ void mWriteCoverageSummaryToStream(gzFile stream, int skip_uncovered) {
 	coverage_t **coverage = global->coverage;
 
 	for (tid=0; tid<n_targets; tid++) {
-		int32_t i;
-		int32_t touched = 0;
+		hts_pos_t i;
+		hts_pos_t touched = 0;
+		hts_pos_t tlen    = global->header->target_len[tid];
 		int64_t sum     = 0;
-		int32_t tlen    = global->header->target_len[tid];
 
 		/* If this target is not covered, deal with it */
 
@@ -213,9 +208,8 @@ int msam_coverage_main(int argc, char* argv[]) {
 	/* common variables */
 
 	const char      *infile;
-	char            *headerfile = NULL;
 
-	samfile_t       *input  = NULL;
+	mSamFile        *input  = NULL;
 
 	const char      *inmode;
 
@@ -344,7 +338,7 @@ int msam_coverage_main(int argc, char* argv[]) {
 
 	inmode = M_INPUT_MODE(arg_samin);
 	infile = arg_samfile->filename[0];
-	input = mOpenSamFile(infile, inmode, headerfile);
+	input = mOpenSamInput(infile, inmode);
 	global->header = input->header;
 
 	if (arg_wordsize->count > 0) {
@@ -371,7 +365,7 @@ int msam_coverage_main(int argc, char* argv[]) {
 	/* Wind-up operations */
 
 	mFreeCoverage();
-	samclose(input);
+	mSamClose(input);
 	arg_freetable(argtable, set_argcount);
 	mFree(argtable);
 

--- a/msam_filter.c
+++ b/msam_filter.c
@@ -1,10 +1,11 @@
 #include "msam.h"
+#include "mBamVector.h"
 
-void mFilterFileWrapper(samfile_t *input, samfile_t *output, int uniqbesthit_only, int besthit_only, int rescore, int invert, int keep_unmapped);
-void mFilterFile(samfile_t *input, samfile_t *output, int (*filter)(mAlignmentSummary*), void (*writer)(samfile_t*, mBamPool*), int rescore, int invert, int keep_unmapped);
-void mFilterFileLite(samfile_t *input, samfile_t *output, void (*writer)(samfile_t*, mBamPool*));
-void mWriteBestHitBamPool(samfile_t *stream, mBamPool *pool);
-void mWriteUniqueBestHitBamPool(samfile_t *stream, mBamPool *pool);
+void mFilterFileWrapper(mSamFile *input, mSamFile *output, int uniqbesthit_only, int besthit_only, int rescore, int invert, int keep_unmapped);
+void mFilterFile(mSamFile *input, mSamFile *output, int (*filter)(mAlignmentSummary*), void (*writer)(mSamFile*, mBamPool*), int rescore, int invert, int keep_unmapped);
+void mFilterFileLite(mSamFile *input, mSamFile *output, void (*writer)(mSamFile*, mBamPool*));
+void mWriteBestHitBamPool(mSamFile *stream, mBamPool *pool);
+void mWriteUniqueBestHitBamPool(mSamFile *stream, mBamPool *pool);
 
 /* Filters return 1 when the condition fails. This makes it easy to call
  * each filter and if one of them fails, you already quit.
@@ -62,7 +63,7 @@ static int filter_lpz(mAlignmentSummary* a) {
 	return _FILTER_L(a) || _FILTER_P(a) || _FILTER_Z(a);
 }
 
-void mFilterFileWrapper(samfile_t *input, samfile_t *output, int uniqbesthit_only, int besthit_only, int rescore, int invert, int keep_unmapped) {
+void mFilterFileWrapper(mSamFile *input, mSamFile *output, int uniqbesthit_only, int besthit_only, int rescore, int invert, int keep_unmapped) {
 
 	/* filter function */
 
@@ -74,7 +75,7 @@ void mFilterFileWrapper(samfile_t *input, samfile_t *output, int uniqbesthit_onl
 
 	/* writer function */
 
-	void (*writer)(samfile_t*, mBamPool*);
+	void (*writer)(mSamFile*, mBamPool*);
 
 	/* Assign filter function */
 
@@ -114,7 +115,7 @@ void mFilterFileWrapper(samfile_t *input, samfile_t *output, int uniqbesthit_onl
  * will go through the same procedure, so no need to maintain two versions of code
  */
 
-void mFilterFile(samfile_t *input, samfile_t *output, int (*filter)(mAlignmentSummary*), void (*writer)(samfile_t*, mBamPool*), int rescore, int invert, int keep_unmapped) {
+void mFilterFile(mSamFile *input, mSamFile *output, int (*filter)(mAlignmentSummary*), void (*writer)(mSamFile*, mBamPool*), int rescore, int invert, int keep_unmapped) {
 
 	/* parameters for rescoring alignment score */
 	int       hit=1, miss=-1;
@@ -137,13 +138,13 @@ void mFilterFile(samfile_t *input, samfile_t *output, int (*filter)(mAlignmentSu
 	current = pool_current(pool);
 
 	prev_read[0] = '\0';
-	while (samread(input, current) >= 0) {
+	while (mSamRead(input, current) >= 0) {
 		bam1_core_t  core = current->core;
 /*
-fprintf(stdout, "%s\t%s\t%d\t%d\t%d\n", bam1_qname(current), prev_read, core.flag, prev_flag, (core.flag|prev_flag) & mutual_pairs);
+fprintf(stdout, "%s\t%s\t%d\t%d\t%d\n", bam_get_qname(current), prev_read, core.flag, prev_flag, (core.flag|prev_flag) & mutual_pairs);
 */
 		if ( (prev_read[0] != '\0') && 
-		     ((strcmp(bam1_qname(current), prev_read) != 0) || 
+		     ((strcmp(bam_get_qname(current), prev_read) != 0) || 
 		      (((core.flag | prev_flag) & mutual_pairs) == mutual_pairs)
 		     )
 		   ) {
@@ -196,7 +197,7 @@ fprintf(stdout, "%s\t%s\t%d\t%d\t%d\n", bam1_qname(current), prev_read, core.fla
 				mDie("Either NM or MD must be present in SAM/BAM input for 'filter' command. Type '%s filter -h' for details.", PROGRAM);
 			}
 
-			bam_cigar2details(&current->core, bam1_cigar(current), &alignment->length, &alignment->query_length, &alignment->query_clip);
+			bam_cigar2details(&current->core, bam_get_cigar(current), &alignment->length, &alignment->query_length, &alignment->query_clip);
 			alignment->edit  = bam_aux2i(nm);
 		}
 
@@ -212,7 +213,7 @@ fprintf(stdout, "%s\t%s\t%d\t%d\t%d\n", bam1_qname(current), prev_read, core.fla
 		}
 
 		prev_flag = core.flag;
-		strncpy(prev_read, bam1_qname(current), 127);
+		strncpy(prev_read, bam_get_qname(current), 127);
 
 		/***
 		 * Do I pass the filter? "filter(alignment) == 1" means failed.
@@ -234,7 +235,7 @@ fprintf(stdout, "%s\t%s\t%d\t%d\t%d\n", bam1_qname(current), prev_read, core.fla
 	mFree(prev_read);
 }
 
-void mFilterFileLite(samfile_t *input, samfile_t *output, void (*writer)(samfile_t*, mBamPool*)) {
+void mFilterFileLite(mSamFile *input, mSamFile *output, void (*writer)(mSamFile*, mBamPool*)) {
 
 	/* parameters for rescoring alignment score */
 
@@ -254,13 +255,13 @@ void mFilterFileLite(samfile_t *input, samfile_t *output, void (*writer)(samfile
 	current = pool_current(pool);
 
 	prev_read[0] = '\0';
-	while (samread(input, current) >= 0) {
+	while (mSamRead(input, current) >= 0) {
 		bam1_core_t  core = current->core;
 /*
-fprintf(stdout, "%s\t%s\t%d\t%d\t%d\n", bam1_qname(current), prev_read, core.flag, prev_flag, (core.flag|prev_flag) & mutual_pairs);
+fprintf(stdout, "%s\t%s\t%d\t%d\t%d\n", bam_get_qname(current), prev_read, core.flag, prev_flag, (core.flag|prev_flag) & mutual_pairs);
 */
 		if ( (prev_read[0] != '\0') && 
-		     ((strcmp(bam1_qname(current), prev_read) != 0) || 
+		     ((strcmp(bam_get_qname(current), prev_read) != 0) || 
 		      (((core.flag | prev_flag) & mutual_pairs) == mutual_pairs)
 		     )
 		   ) {
@@ -270,7 +271,7 @@ fprintf(stdout, "%s\t%s\t%d\t%d\t%d\n", bam1_qname(current), prev_read, core.fla
 		}
 
 		prev_flag = core.flag;
-		strncpy(prev_read, bam1_qname(current), 127);
+		strncpy(prev_read, bam_get_qname(current), 127);
 
 		/* Ignore an unmapped read */
 
@@ -285,7 +286,7 @@ fprintf(stdout, "%s\t%s\t%d\t%d\t%d\n", bam1_qname(current), prev_read, core.fla
 	mFree(prev_read);
 }
 
-void mWriteBestHitBamPool(samfile_t *stream, mBamPool *pool) {
+void mWriteBestHitBamPool(mSamFile *stream, mBamPool *pool) {
 	int        i;
 	bam1_t   **elem       = pool->elem;
 	int       *score      = (int*) mCalloc(pool->limit, sizeof(int));
@@ -294,7 +295,7 @@ void mWriteBestHitBamPool(samfile_t *stream, mBamPool *pool) {
 	for (i=0; i<pool->size; i++) {
 		uint8_t *as = bam_aux_get(elem[i], "AS");
 /*
-fprintf(stdout, "BEST: %2d/%2d, %s, %d\n", i, pool->size, bam1_qname(elem[i]), elem[i]->core.pos);
+fprintf(stdout, "BEST: %2d/%2d, %s, %d\n", i, pool->size, bam_get_qname(elem[i]), elem[i]->core.pos);
 */
 		if (as) {
 			score[i] = bam_aux2i(as);
@@ -307,13 +308,13 @@ fprintf(stdout, "BEST: %2d/%2d, %s, %d\n", i, pool->size, bam1_qname(elem[i]), e
 	}
 	for (i=0; i<pool->size; i++) {
 		if (score[i] == best_score) {
-			samwrite(stream, elem[i]);
+			mSamWrite(stream, elem[i]);
 		}
 	}
 	mFree(score);
 }
 
-void mWriteUniqueBestHitBamPool(samfile_t *stream, mBamPool *pool) {
+void mWriteUniqueBestHitBamPool(mSamFile *stream, mBamPool *pool) {
 	int        i;
 	bam1_t   **elem       = pool->elem;
 	int       *score      = (int*) mCalloc(pool->limit, sizeof(int));
@@ -337,7 +338,7 @@ void mWriteUniqueBestHitBamPool(samfile_t *stream, mBamPool *pool) {
 	if (best_count == 1) {
 		for (i=0; i<pool->size; i++) {
 			if (score[i] == best_score) {
-				samwrite(stream, elem[i]);
+				mSamWrite(stream, elem[i]);
 			}
 		}
 	}
@@ -352,8 +353,8 @@ int msam_filter_main(int argc, char* argv[]) {
 
 	const char      *infile = NULL;
 
-	samfile_t       *input  = NULL;
-	samfile_t       *output = NULL;
+	mSamFile        *input  = NULL;
+	mSamFile        *output = NULL;
 
 	const char      *inmode;
 	char             outmode[6];
@@ -548,9 +549,9 @@ int msam_filter_main(int argc, char* argv[]) {
 	/* General operations */
 
 	infile = arg_samfile->filename[0];
-	input = mOpenSamFile(infile, inmode, NULL);
+	input = mOpenSamInput(infile, inmode);
 	global->header = input->header;
-	output = samopen("-", outmode, global->header);
+	output = mOpenSamOutput("-", outmode, global->header);
 
 	/* Specific operations */
 
@@ -558,8 +559,8 @@ int msam_filter_main(int argc, char* argv[]) {
 
 	/* Wind-up operations */
 
-	samclose(input);
-	samclose(output);
+	mSamClose(input);
+	mSamClose(output);
 	arg_freetable(argtable, set_argcount);
 	mFree(argtable);
 	mFreeGlobal();

--- a/msam_helper.c
+++ b/msam_helper.c
@@ -1,5 +1,8 @@
 #include "msam.h"
 
+/*
+ * Handle msam_global global variable
+ */
 void mInitGlobal() {
 	global = (msam_global*) mMalloc(sizeof(msam_global));
 	global->MIN_LENGTH = 0;
@@ -29,10 +32,14 @@ void mFreeGlobal() {
 	global = NULL;
 }
 
+/*
+ * Useful functions for printing information
+ */
+
 void mPrintHelp (const char *subprogram, void **argtable) {
 	fprintf(stdout, "Usage:\n------\n\n%s %s", PROGRAM, subprogram);
 	arg_print_syntax(stdout, argtable, "\n");
-	fprintf(stdout,       "\nGeneral options:\n"
+	fprintf(stdout, "\nGeneral options:\n"
 				"----------------\n\n"
 				"These options specify the input/output formats of BAM/SAM files \n"
 				"(same meaning as in 'samtools view'):\n");
@@ -41,7 +48,7 @@ void mPrintHelp (const char *subprogram, void **argtable) {
 
 void mPrintCommandLine(FILE *output, int argc, char *argv[]) {
 	int i;
-    fprintf(output, "# %s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
+	fprintf(output, "# %s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
 	fprintf(output, "# Command: msamtools");
 	for (i=0; i<argc; i++) fprintf(output, " %s", argv[i]);
 	fprintf(output, "\n");
@@ -49,7 +56,7 @@ void mPrintCommandLine(FILE *output, int argc, char *argv[]) {
 
 void mPrintCommandLineGzip(gzFile output, int argc, char *argv[]) {
 	int i;
-    gzprintf(output, "# %s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
+	gzprintf(output, "# %s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
 	gzprintf(output, "# Command: msamtools");
 	for (i=0; i<argc; i++) gzprintf(output, " %s", argv[i]);
 	gzprintf(output, "\n");
@@ -65,28 +72,84 @@ void mMultipleFileError(const char *subprogram, void **argtable) {
 	mQuit("");
 }
 
-samfile_t* mOpenSamFile(const char *filename, const char *inmode, char *headerfile) {
-	samfile_t *input;
+/*
+ * Handle sam file object
+ */
+mSamFile* mOpenSamInput(const char *filename, const char *inmode) {
+	mSamFile *input;
 
-	/* open input file */
-	/* since you pass headerfile, if there is a headerfile, it will be used */
+	input = malloc(sizeof(mSamFile));
+	if (input == NULL)
+		mDie("Out of memory");
 
-	input = samopen(filename, inmode, headerfile);
-	if (input == NULL) 
+	input->file = sam_open(filename, inmode);
+	if (input->file == NULL)
 		mDie("Cannot open %s for reading", filename);
+
+	input->header = sam_hdr_read(input->file);
+	if (input->header == NULL)
+		mDie("Cannot read header from %s", filename);
 
 	return input;
 }
 
+mSamFile* mOpenSamOutput(const char *filename, const char *outmode,
+                         const sam_hdr_t *header) {
+	mSamFile *output;
+
+	output = malloc(sizeof(mSamFile));
+	if (output == NULL)
+		mDie("Out of memory");
+
+	output->file = sam_open(filename, outmode);
+	if (output->file == NULL)
+		mDie("Cannot open %s for writing", filename);
+
+	output->header = sam_hdr_dup(header);
+	if (output->header == NULL)
+		mDie("Cannot duplicate SAM header");
+
+	if (strchr(outmode, 'b') != NULL || strchr(outmode, 'h') != NULL) {
+		if (sam_hdr_write(output->file, output->header) < 0)
+			mDie("Cannot write SAM header");
+	}
+
+	return output;
+}
+
+int mSamRead(mSamFile *input, bam1_t *b) {
+	return sam_read1(input->file, input->header, b);
+}
+
+int mSamWrite(mSamFile *output, bam1_t *b) {
+	return sam_write1(output->file, output->header, b);
+}
+
+int mSamClose(mSamFile *stream) {
+	int ret;
+
+	if (stream == NULL)
+		return 0;
+
+	ret = sam_close(stream->file);
+	sam_hdr_destroy(stream->header);
+	free(stream);
+
+	return ret;
+}
+
+/*
+ * Ensure that a list of sam/bam files have the same header
+ */
 int mHeaderCheck(int count, const char* filenames[], const char *inmode) {
 	int i, j;
-	samfile_t    *sam1    = mOpenSamFile(filenames[0], inmode, NULL);
-	bam_header_t *header1 = sam1->header;
+	mSamFile  *sam1    = mOpenSamInput(filenames[0], inmode);
+	sam_hdr_t *header1 = sam1->header;
 	if (header1 == 0)
 		mDie("No header found in %s. Please fix your bamfile!", filenames[0]);
 	for (i=1; i<count; i++) {
-		samfile_t *sam2 = mOpenSamFile(filenames[i], inmode, NULL);
-		bam_header_t *header2 = sam2->header;
+		mSamFile  *sam2 = mOpenSamInput(filenames[i], inmode);
+		sam_hdr_t *header2 = sam2->header;
 		if (header2 == 0)
 			mDie("No header found in %s. Please fix your bamfile!", filenames[i]);
 		if (header1->n_targets != header2->n_targets) {
@@ -103,12 +166,15 @@ int mHeaderCheck(int count, const char* filenames[], const char *inmode) {
 				mDie("@SQ name mismatch");
 			}
 		}
-		samclose(sam2);
+		mSamClose(sam2);
 	}
-	samclose(sam1);
+	mSamClose(sam1);
 	return 1;
 }
 
+/*
+ * Convenient functions for handling zoeHash
+ */
 zoeHash mReadIntegerHash(const char *filename) {
 	char     line[2048];
 	char     key[128];

--- a/msam_profile.c
+++ b/msam_profile.c
@@ -1,4 +1,5 @@
 #include "msam.h"
+#include "mBamVector.h"
 #include "zoeTools.h"
 
 #define MULTI_ADD_ALL (1)
@@ -15,7 +16,7 @@
 #define RIGHT_ALIGN (2)
 
 void mInitInsertCounts(int share_type);
-int  mEstimateInsertCountOnFile(samfile_t *input, int share_type);
+int  mEstimateInsertCountOnFile(mSamFile *input, int share_type);
 void mWriteCompressedSeqAbundance();
 mMatrix* mInsertCountToAbundanceMatrix(int row, const char* rowname, int share_type);
 
@@ -200,7 +201,7 @@ void mEstimateInsertCountOnPool(mBamPool *pool, int share_type) {
 
 /* Estimate abundance on a given bamfile, by iterating through the alignment groups. */
 
-int mEstimateInsertCountOnFile(samfile_t *input, int share_type) {
+int mEstimateInsertCountOnFile(mSamFile *input, int share_type) {
 
 	int       pool_limit   = 64;
 	uint32_t  insert_count = 0;
@@ -218,17 +219,17 @@ int mEstimateInsertCountOnFile(samfile_t *input, int share_type) {
 	/* But here, mate-pairs are considered together as inserts.    */
 	/* So no need to check for mate-pair differences. Only qnames. */
 	prev_read[0] = '\0';
-	while (samread(input, current) >= 0) {
+	while (mSamRead(input, current) >= 0) {
 		if (current->core.tid == -1) {
 			continue;
 		}
-		if ( prev_read[0] != '\0' && strcmp(bam1_qname(current), prev_read) != 0) {
+		if ( prev_read[0] != '\0' && strcmp(bam_get_qname(current), prev_read) != 0) {
 			mEstimateInsertCountOnPool(pool, share_type);
 			mReOriginateBamPool(pool);
 			current = pool_current(pool);
 			insert_count++;
 		}
-		strncpy(prev_read, bam1_qname(current), 127);
+		strncpy(prev_read, bam_get_qname(current), 127);
 		current = mAdvanceBamPool(pool);
 	}
 	mEstimateInsertCountOnPool(pool, share_type);
@@ -462,7 +463,7 @@ int msam_profile_main(int argc, char* argv[]) {
 
 	const char      *infile;
 	const char      *inmode;
-	samfile_t       *input  = NULL;
+	mSamFile        *input  = NULL;
 	mMatrix         *abundance;
 	int              share_type    = -1;
 	int              unit_type     = -1;
@@ -642,7 +643,7 @@ int msam_profile_main(int argc, char* argv[]) {
 	inmode = M_INPUT_MODE(arg_samin);
 
 	infile = arg_samfile->filename[0];
-	input = mOpenSamFile(infile, inmode, NULL);
+	input = mOpenSamInput(infile, inmode);
 	global->header = input->header;
 
 	/* multi-mapper share type */
@@ -944,7 +945,7 @@ int msam_profile_main(int argc, char* argv[]) {
 		zoeDeleteHash(sequences);
 	}
 
-	samclose(input);
+	mSamClose(input);
 	arg_freetable(argtable, set_argcount);
 	mFree(argtable);
 

--- a/msam_summary.c
+++ b/msam_summary.c
@@ -1,11 +1,12 @@
 #include "msam.h"
+#include "mBamVector.h"
 
 #define MAP_STATS (0)
 #define UNMAP_STATS (1)
 #define EDIT_STATS (2)
 #define SCOR_STATS (3)
 
-void mSummarizeAlignmentsHQ(samfile_t *input, FILE *output) {
+void mSummarizeAlignmentsHQ(mSamFile *input, FILE *output) {
 
 	int     i;
 	int     min_edit = 4096;
@@ -16,15 +17,15 @@ void mSummarizeAlignmentsHQ(samfile_t *input, FILE *output) {
 	char  **target_name = global->header->target_name;
 
 	prev_read[0] = '\0';
-	while (samread(input, b) >= 0) {
+	while (mSamRead(input, b) >= 0) {
 
 		int edit;
 		bam1_core_t *core = &b->core;
 		int tid           = core->tid;
-		int start         = core->pos;
-		int end           = bam_calend(core, bam1_cigar(b));
+		hts_pos_t start   = core->pos;
+		hts_pos_t end     = bam_endpos(b);
 
-		if (prev_read[0] != '\0' && strcmp(bam1_qname(b), prev_read) != 0) {
+		if (prev_read[0] != '\0' && strcmp(bam_get_qname(b), prev_read) != 0) {
 			if (min_edit != 4096) {
 				dist[min_edit]++;
 				min_edit = 4096;
@@ -33,10 +34,10 @@ void mSummarizeAlignmentsHQ(samfile_t *input, FILE *output) {
 		bam_get_extended_summary(b, alignment);
 		if (bam_highquality_differences_only(b, 20)) {
 			edit = alignment->mismatch + alignment->gapopen + alignment->gapextend;
-			fprintf(output, "%s\t%d\t%s\t%d\t%d\t%d\t%d\n", bam1_qname(b), alignment->query_length, target_name[tid], start, end, alignment->match, edit);
+			fprintf(output, "%s\t%d\t%s\t%" PRId64 "\t%" PRId64 "\t%d\t%d\n", bam_get_qname(b), alignment->query_length, target_name[tid], start, end, alignment->match, edit);
 			if (edit < min_edit) min_edit = edit;
 		}
-		strncpy(prev_read, bam1_qname(b), 127);
+		strncpy(prev_read, bam_get_qname(b), 127);
 	}
 	bam_destroy1(b);
 	if (min_edit != 4096) dist[min_edit]++;
@@ -48,78 +49,6 @@ void mSummarizeAlignmentsHQ(samfile_t *input, FILE *output) {
 	mFree(prev_read);
 }
 
-void mSummarizeAlignments_v1(samfile_t *input, FILE *output) {
-
-	int     i;
-	int     edit = 0;
-	char   *prev_read = (char*) mCalloc(128, sizeof(char));
-	bam1_t *b    = bam_init1();
-	long   *dist = (long*) mCalloc(500, sizeof(long));
-	mAlignmentSummary* alignment = (mAlignmentSummary*) mMalloc(sizeof(mAlignmentSummary));
-	char  **target_name = global->header->target_name;
-	uint32_t *target_len = global->header->target_len;
-
-	prev_read[0] = '\0';
-	while (samread(input, b) >= 0) {
-
-		bam1_core_t *core = &b->core;
-		int tid           = core->tid;
-		int start         = core->pos + 1;
-		int end           = bam_calend(core, bam1_cigar(b));
-
-		if (prev_read[0] != '\0' && strcmp(bam1_qname(b), prev_read) != 0) {
-/* wrong uninitialized reference. but not planning to fix this bug as this function is deprecated */
-			dist[edit]++;
-		}
-
-		/* Skip reads mapping to the edges of ref */
-		if ((start < 150) || (target_len[tid] - end < 150)) continue;
-
-		/* Skip non-primary multi-mappers */
-		if (core->flag & BAM_FSECONDARY) continue;
-
-		bam_get_extended_summary(b, alignment);
-		edit = alignment->edit;
-		fprintf(output, "%s\t%d\t%s\t%d\t%d\t%d\t%d\n", bam1_qname(b), alignment->query_length, target_name[tid], start, end, alignment->match, edit);
-		strncpy(prev_read, bam1_qname(b), 127);
-	}
-	bam_destroy1(b);
-	dist[edit]++;
-	for (i=0; i<500; i++) {
-		if (dist[i] > 0) {
-			fprintf(stderr, "%d\t%ld\n", i, dist[i]);
-		}
-	}
-	mFree(prev_read);
-}
-
-void mSummarizeAlignments_v2(samfile_t *input, FILE *output) {
-
-	int     edit;
-	bam1_t *b    = bam_init1();
-	mAlignmentSummary* alignment = (mAlignmentSummary*) mMalloc(sizeof(mAlignmentSummary));
-	char  **target_name = global->header->target_name;
-	uint32_t *target_len = global->header->target_len;
-
-	while (samread(input, b) >= 0) {
-
-		bam1_core_t *core = &b->core;
-		int tid           = core->tid;
-		int start         = core->pos + 1;
-		int end           = bam_calend(core, bam1_cigar(b));
-
-		/* Skip reads mapping to the edges of ref */
-		if ((start < 150) || (target_len[tid] - end < 150)) continue;
-
-		/* Skip non-primary multi-mappers */
-		if (core->flag & BAM_FSECONDARY) continue;
-
-		bam_get_extended_summary(b, alignment);
-		edit = alignment->edit;
-		fprintf(output, "%s\t%d\t%s\t%d\t%d\t%d\t%d\n", bam1_qname(b), alignment->query_length, target_name[tid], start, end, alignment->match, edit);
-	}
-	bam_destroy1(b);
-}
 
 /***************************************************************
  * Summarize alignment statistics for PRIMARY ALIGNMENTS ONLY! *
@@ -130,43 +59,44 @@ void mSummarizeAlignments_v2(samfile_t *input, FILE *output) {
  *  Also, I count softclip as mismatch. So beware!             *
  ***************************************************************/
 
-int mCountInserts(samfile_t *input) {
+int mCountInserts(mSamFile *input) {
 
 	bam1_t *b         = bam_init1();
 	char   *prev_read = (char*) mCalloc(128, sizeof(char));
 	int     count     = 0;
 
-	while (samread(input, b) >= 0) {
+	while (mSamRead(input, b) >= 0) {
 
 		bam1_core_t *core = &b->core;
 
 		/* Skip unmapped */
 		if (core->flag & BAM_FUNMAP) continue;
 
-		if (strcmp(bam1_qname(b), prev_read) != 0) {
+		if (strcmp(bam_get_qname(b), prev_read) != 0) {
 			count++;
 		}
 
-		strncpy(prev_read, bam1_qname(b), 127);
+		strncpy(prev_read, bam_get_qname(b), 127);
 	}
 	bam_destroy1(b);
 	mFree(prev_read);
 	return count;
 }
 
-void mSummarizeAlignments(samfile_t *input, FILE *output, uint32_t edge_len) {
+void mSummarizeAlignments(mSamFile *input, FILE *output, uint32_t edge_len) {
 
 	bam1_t *b    = bam_init1();
 	mAlignmentSummary* alignment = (mAlignmentSummary*) mMalloc(sizeof(mAlignmentSummary));
 	char  **target_name = global->header->target_name;
 	uint32_t *target_len = global->header->target_len;
 
-	while (samread(input, b) >= 0) {
+	while (mSamRead(input, b) >= 0) {
 
 		bam1_core_t *core = &b->core;
 		int tid           = core->tid;
-		uint32_t start    = core->pos + 1; /* I know I am assigning int to uint, but bam.c does it too! */
-		uint32_t end      = bam_calend(core, bam1_cigar(b));
+		hts_pos_t start   = core->pos + 1;
+		hts_pos_t end     = bam_endpos(b);
+		hts_pos_t tlen    = target_len[tid];
 
 		int32_t  glocal_len;
 
@@ -177,18 +107,18 @@ void mSummarizeAlignments(samfile_t *input, FILE *output, uint32_t edge_len) {
 		if (core->flag & BAM_FSECONDARY) continue;
 
 		/* Skip reads mapping to the edges of ref */
-		if ((start < edge_len) || (target_len[tid] - end < edge_len)) continue;
+		if ((start < edge_len) || (tlen - end < edge_len)) continue;
 
 		bam_get_extended_summary(b, alignment);
 		glocal_len = alignment->length + alignment->query_clip;
-		fprintf(output, "%s\t%d\t%s\t%d\t%d\t%.1f\n", bam1_qname(b), alignment->query_length, target_name[tid], glocal_len, alignment->match, 100.0 - 100.0*alignment->edit/glocal_len);
+		fprintf(output, "%s\t%d\t%s\t%d\t%d\t%.1f\n", bam_get_qname(b), alignment->query_length, target_name[tid], glocal_len, alignment->match, 100.0 - 100.0*alignment->edit/glocal_len);
 
 	}
 	bam_destroy1(b);
 	mFree(alignment);
 }
 
-void mSummarizeAlignmentsStats(int stats_type, samfile_t *input, FILE *output, uint32_t edge_len) {
+void mSummarizeAlignmentsStats(int stats_type, mSamFile *input, FILE *output, uint32_t edge_len) {
 
 	int     i;
 	int     idx;
@@ -202,12 +132,13 @@ void mSummarizeAlignmentsStats(int stats_type, samfile_t *input, FILE *output, u
 	uint64_t score    = 0;
 	uint32_t stats[5];
 
-	while (samread(input, b) >= 0) {
+	while (mSamRead(input, b) >= 0) {
 
 		bam1_core_t *core = &b->core;
-		int      tid      = core->tid;
-		int32_t  start    = core->pos + 1;
-		uint32_t end      = bam_calend(core, bam1_cigar(b));
+		int       tid     = core->tid;
+		hts_pos_t start   = core->pos + 1;
+		hts_pos_t end     = bam_endpos(b);
+		hts_pos_t tlen    = target_len[tid];
 
 		/* Skip unmapped */
 		if (core->flag & BAM_FUNMAP) continue;
@@ -216,7 +147,7 @@ void mSummarizeAlignmentsStats(int stats_type, samfile_t *input, FILE *output, u
 		if (core->flag & BAM_FSECONDARY) continue;
 
 		/* Skip reads mapping to the edges of ref */
-		if ((start < (int32_t) edge_len) || (target_len[tid] - end < edge_len)) continue;
+		if ((start < edge_len) || (tlen - end < edge_len)) continue;
 
 		bam_get_extended_summary(b, alignment);
 
@@ -257,9 +188,8 @@ int msam_summary_main(int argc, char* argv[]) {
 	/* common variables */
 
 	const char      *infile;
-	char            *headerfile = NULL;
 
-	samfile_t       *input  = NULL;
+	mSamFile        *input  = NULL;
 
 	const char      *inmode;
 
@@ -362,7 +292,7 @@ int msam_summary_main(int argc, char* argv[]) {
 	/* General operations */
 
 	infile = arg_samfile->filename[0];
-	input = mOpenSamFile(infile, inmode, headerfile);
+	input = mOpenSamInput(infile, inmode);
 	global->header = input->header;
 
 	/* Specific operations */
@@ -397,7 +327,7 @@ int msam_summary_main(int argc, char* argv[]) {
 
 	/* Wind-up operations */
 
-	samclose(input);
+	mSamClose(input);
 	arg_freetable(argtable, set_argcount);
 	mFree(argtable);
 

--- a/msamtools.c
+++ b/msamtools.c
@@ -8,7 +8,7 @@ static int usage(FILE *out)
 {
 	fprintf(out, "\n");
 	fprintf(out, "Program: %s (Metagenomics-related extension to samtools)\n", PROGRAM);
-    fprintf(out, "Version: %s (using samtools/htslib %s)\n", PACKAGE_VERSION, HTSLIB_VERSION);
+    fprintf(out, "Version: %s (using htslib %s)\n", PACKAGE_VERSION, HTSLIB_VERSION);
 	fprintf(out, "\n");
 	fprintf(out, "Usage:   %s <command> [options]\n\n", PROGRAM);
 	fprintf(out, "Commands:\n");

--- a/msamtools.c
+++ b/msamtools.c
@@ -1,4 +1,5 @@
 #include "msam.h"
+#include "msam_version.h"
 
 /* This main entry file was rewritten after being inspired by the samtools codebase. */
 
@@ -8,7 +9,7 @@ static int usage(FILE *out)
 {
 	fprintf(out, "\n");
 	fprintf(out, "Program: %s (Metagenomics-related extension to samtools)\n", PROGRAM);
-    fprintf(out, "Version: %s (using htslib %s)\n", PACKAGE_VERSION, HTSLIB_VERSION);
+    fprintf(out, "Version: %s (git %s; using htslib %s)\n", PACKAGE_VERSION, MSAM_GIT_COMMIT, HTSLIB_VERSION);
 	fprintf(out, "\n");
 	fprintf(out, "Usage:   %s <command> [options]\n\n", PROGRAM);
 	fprintf(out, "Commands:\n");

--- a/versions.txt
+++ b/versions.txt
@@ -1,1 +1,1 @@
-samtools_version = 1.9
+htslib_version = 1.24


### PR DESCRIPTION
# Upgrade HTSlib dependency to 1.24

## Summary

This PR modernizes the samtools/HTSlib dependency used to build msamtools.

Previously, msamtools downloaded samtools 1.9 and linked against both the legacy samtools `libbam.a` compatibility layer and HTSlib 1.9. This PR removes the samtools build/API dependency and updates msamtools to use the current HTSlib 1.24 API directly.

The intent of this PR is to preserve existing msamtools behavior while updating the dependency and build infrastructure.

## Main changes

* replace the bundled samtools 1.9 dependency with HTSlib 1.24
* build and statically link directly against `libhts.a`
* migrate legacy samtools APIs to current HTSlib APIs
* add a small local SAM/BAM I/O wrapper around `sam_open()`, `sam_read1()`, `sam_write1()`, and related header handling
* update alignment coordinate handling to use `hts_pos_t` where appropriate
* update handling of HTSlib functions whose return values must now be checked
* remove obsolete samtools build machinery under `deps/`
* update Docker builds so samtools is downloaded and built independently for inclusion in the image
* keep the Docker samtools version synchronized with the HTSlib version used by msamtools
* update third-party licensing information to reflect that samtools is now included only as a separate executable in the Docker image
* modernize static archive flags for current `ar` implementations
* add Git commit provenance to the msamtools version output
* embed the commit ID in source distribution tarballs so builds from release tarballs retain their provenance
* prevent `make dist` and `make distcheck` from creating distributions from a dirty Git working tree

Example version output:

```text
Program: msamtools (Metagenomics-related extension to samtools)
Version: 1.1.3 (git 1bc2b6fae5cf; using htslib 1.24)
```

## Validation

The updated code:

* compiles successfully against HTSlib 1.24
* passes the existing regression tests against msamtools v1.1.3
* passes the recently added validation tests for profiling synthetic alignments
* installs successfully with `make install`
* passes source-distribution builds
* preserves the Git commit ID when building from the generated dist tarball
* builds successfully in Docker from the dist tarball
* preserves the same Git provenance in the Docker-built executable

## Scope

This PR is intentionally limited to dependency, API, build, packaging, and provenance modernization. Existing filtering and profiling semantics are intended to remain unchanged.
