### PR TITLE
Validate QNAME grouping for profile and best-hit filtering

### DIFF
--- a/msam.h
+++ b/msam.h
@@ -61,34 +61,48 @@ typedef struct {
 	size_t      replay_index;
 } mSamFile;
 
-/* Wrapper functions for mSamFile */
+/* objects to track whether sam file is qname-grouped */
 
-mSamFile* mOpenSamInput(const char *filename, const char *inmode);
-mSamFile* mOpenSamOutput(const char *filename, const char *outmode,
-                         const sam_hdr_t *header);
-int       mSamRead(mSamFile *input, bam1_t *b);
-int       mSamWrite(mSamFile *output, bam1_t *b);
-int       mSamClose(mSamFile *stream);
+typedef enum {
+	MSAM_QNAME_NOT_REQUIRED = 0,
+	MSAM_QNAME_HEADER_CONFIRMED,
+	MSAM_QNAME_SAMPLE_OK,
+	MSAM_QNAME_SAMPLE_WARNING
+} mQNameCheckStatus;
 
-/* Helper functions */
+typedef struct {
+	mQNameCheckStatus status;
+	size_t            qname_records_checked;
+	size_t            input_records_checked;
+	size_t            mapped_records_checked;
+} mQNameCheckResult;
 
-void       mMultipleFileError(const char *subprogram, void **argtable);
-int        mHeaderCheck(int count, const char* filenames[], const char *inmode);
-
-zoeHash mReadIntegerHash(const char *filename);
-void    mEmptyZoeHash(zoeHash hash);
+/* Helper functions for global variables struct */
 
 void mInitGlobal();
 void mFreeGlobal();
 
-FILE* mInitOutputStream(const char *filename, int gzip);
-void  mFreeOutputStream(FILE *output, int gzip);
+/* Wrapper functions for mSamFile */
+
+mSamFile* mOpenSamInput(const char *filename, const char *inmode);
+mSamFile* mOpenSamOutput(const char *filename, const char *outmode, const sam_hdr_t *header);
+int       mSamRead(mSamFile *input, bam1_t *b);
+int       mSamWrite(mSamFile *output, bam1_t *b);
+int       mSamClose(mSamFile *stream);
+
+/* Helper functions for qname-grouping test */
+
+mQNameCheckResult mQNameCheckNotRequired(void);
+mQNameCheckResult mSamCheckQNameGrouping(mSamFile *input);
+
+/* Other helper functions */
+
+void mAddSamProvenance(sam_hdr_t *header, int argc, char *argv[], const mQNameCheckResult *qname_check);
+void mPrintProfileProvenanceGzip(gzFile output, int argc, char *argv[], const mQNameCheckResult *qname_check);
+void mMultipleFileError(const char *subprogram, void **argtable);
+void mPrintHelp (const char *subprogram, void **argtable);
 
 #define M_INPUT_MODE(arg_samin) ((arg_samin->count == 0)?"rb":"r")
-
-void mPrintHelp (const char *subprogram, void **argtable);
-void mPrintCommandLine(FILE *output, int argc, char *argv[]);
-void mPrintCommandLineGzip(gzFile output, int argc, char *argv[]);
 
 /* Main functions for the subprograms */
 

--- a/msam.h
+++ b/msam.h
@@ -54,8 +54,11 @@ extern msam_global *global;
 /* New wrapper struct to replace old samfile_t */
 
 typedef struct {
-	samFile   *file;
-	sam_hdr_t *header;
+	samFile    *file;
+	sam_hdr_t  *header;
+	bam1_t    **replay_buffer;
+	size_t      replay_count;
+	size_t      replay_index;
 } mSamFile;
 
 /* Wrapper functions for mSamFile */

--- a/msam_filter.c
+++ b/msam_filter.c
@@ -495,12 +495,15 @@ int msam_filter_main(int argc, char* argv[]) {
 		fprintf(stdout, "--besthit cannot be combined with --uniqhit\n");
 		mPrintHelp(subprogram, argtable);
 		mQuit("");
-/*
-	} else if (arg_minlength->count == 0 && arg_minpercentid->count == 0 && arg_minppt->count == 0 && arg_minqfrac->count == 0) {
-		fprintf(stdout, "--mode filter needs -l, -p, --ppt or -z\n");
+	} else if (arg_minlength->count       == 0 &&
+	           arg_minpercentid->count    == 0 &&
+	           arg_minppt->count          == 0 &&
+	           arg_uniqbesthitonly->count == 0 &&
+	           arg_besthitonly->count     == 0 &&
+	           arg_minqfrac->count        == 0) {
+		fprintf(stdout, "--mode filter needs -l, -p, --ppt, -z, --besthit or --uniqhit\n");
 		mPrintHelp(subprogram, argtable);
 		mQuit("");
-*/
 	} else {
 		int32_t percent_id  = 0;
 		if (arg_minpercentid->count > 0) {

--- a/msam_filter.c
+++ b/msam_filter.c
@@ -355,6 +355,8 @@ int msam_filter_main(int argc, char* argv[]) {
 
 	mSamFile        *input  = NULL;
 	mSamFile        *output = NULL;
+	sam_hdr_t       *output_header = NULL;
+	mQNameCheckResult qname_check;
 
 	const char      *inmode;
 	char             outmode[6];
@@ -551,7 +553,23 @@ int msam_filter_main(int argc, char* argv[]) {
 	infile = arg_samfile->filename[0];
 	input = mOpenSamInput(infile, inmode);
 	global->header = input->header;
-	output = mOpenSamOutput("-", outmode, global->header);
+
+	if (arg_besthitonly->count > 0 || arg_uniqbesthitonly->count > 0) {
+		qname_check = mSamCheckQNameGrouping(input);
+	} else {
+		qname_check = mQNameCheckNotRequired();
+	}
+
+	/*
+	 * Annotate only the output-header copy.  The input header remains
+	 * untouched.
+	 */
+	output_header = sam_hdr_dup(global->header);
+	if (output_header == NULL)
+		mDie("Cannot duplicate SAM header for output provenance");
+	mAddSamProvenance(output_header, argc, argv, &qname_check);
+	output = mOpenSamOutput("-", outmode, output_header);
+	sam_hdr_destroy(output_header);
 
 	/* Specific operations */
 

--- a/msam_helper.c
+++ b/msam_helper.c
@@ -90,6 +90,10 @@ mSamFile* mOpenSamInput(const char *filename, const char *inmode) {
 	if (input->header == NULL)
 		mDie("Cannot read header from %s", filename);
 
+	input->replay_buffer = NULL;
+	input->replay_count = 0;
+	input->replay_index = 0;
+
 	return input;
 }
 
@@ -109,6 +113,10 @@ mSamFile* mOpenSamOutput(const char *filename, const char *outmode,
 	if (output->header == NULL)
 		mDie("Cannot duplicate SAM header");
 
+	output->replay_buffer = NULL;
+	output->replay_count = 0;
+	output->replay_index = 0;
+
 	if (strchr(outmode, 'b') != NULL || strchr(outmode, 'h') != NULL) {
 		if (sam_hdr_write(output->file, output->header) < 0)
 			mDie("Cannot write SAM header");
@@ -118,6 +126,26 @@ mSamFile* mOpenSamOutput(const char *filename, const char *outmode,
 }
 
 int mSamRead(mSamFile *input, bam1_t *b) {
+	if (input->replay_index < input->replay_count) {
+		bam1_t *buffered = input->replay_buffer[input->replay_index];
+
+		if (bam_copy1(b, buffered) == NULL)
+			mDie("Out of memory while replaying buffered SAM/BAM record");
+
+		bam_destroy1(buffered);
+		input->replay_buffer[input->replay_index] = NULL;
+		input->replay_index++;
+
+		if (input->replay_index == input->replay_count) {
+			free(input->replay_buffer);
+			input->replay_buffer = NULL;
+			input->replay_count = 0;
+			input->replay_index = 0;
+		}
+
+		return 0;
+	}
+
 	return sam_read1(input->file, input->header, b);
 }
 
@@ -127,9 +155,18 @@ int mSamWrite(mSamFile *output, bam1_t *b) {
 
 int mSamClose(mSamFile *stream) {
 	int ret;
+	size_t i;
 
 	if (stream == NULL)
 		return 0;
+
+	if (stream->replay_buffer != NULL) {
+		for (i=stream->replay_index; i<stream->replay_count; i++) {
+			if (stream->replay_buffer[i] != NULL)
+				bam_destroy1(stream->replay_buffer[i]);
+		}
+		free(stream->replay_buffer);
+	}
 
 	ret = sam_close(stream->file);
 	sam_hdr_destroy(stream->header);

--- a/msam_helper.c
+++ b/msam_helper.c
@@ -1,4 +1,14 @@
 #include "msam.h"
+#include "msam_version.h"
+
+#define QNAME_GROUP_CHECK_RECORDS 10000
+#define COORD_ORDER_CHECK_RECORDS 100000
+#define COORD_ORDER_MIN_RECORDS   10000
+
+typedef struct {
+	size_t first_record;
+	size_t last_record;
+} mClosedQNameGroup;
 
 /*
  * Handle msam_global global variable
@@ -46,26 +56,134 @@ void mPrintHelp (const char *subprogram, void **argtable) {
 	arg_print_glossary(stdout, argtable, "  %-25s %s\n");
 }
 
-void mPrintCommandLine(FILE *output, int argc, char *argv[]) {
-	int i;
-	fprintf(output, "# %s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
-	fprintf(output, "# Command: msamtools");
-	for (i=0; i<argc; i++) fprintf(output, " %s", argv[i]);
-	fprintf(output, "\n");
+static char *mBuildCommandLine(int argc, char *argv[]) {
+	char **full_argv;
+	char  *command;
+	int    i;
+
+	full_argv = (char**) mMalloc((argc + 1) * sizeof(char*));
+	full_argv[0] = (char*) PROGRAM;
+	for (i=0; i<argc; i++) {
+		full_argv[i+1] = argv[i];
+	}
+
+	command = stringify_argv(argc + 1, full_argv);
+	mFree(full_argv);
+	if (command == NULL)
+		mDie("Cannot construct command line for provenance");
+
+	return command;
 }
 
-void mPrintCommandLineGzip(gzFile output, int argc, char *argv[]) {
-	int i;
-	gzprintf(output, "# %s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
-	gzprintf(output, "# Command: msamtools");
-	for (i=0; i<argc; i++) gzprintf(output, " %s", argv[i]);
-	gzprintf(output, "\n");
+mQNameCheckResult mQNameCheckNotRequired(void) {
+	mQNameCheckResult result;
+
+	result.status = MSAM_QNAME_NOT_REQUIRED;
+	result.qname_records_checked = 0;
+	result.input_records_checked = 0;
+	result.mapped_records_checked = 0;
+	return result;
+}
+
+static void mFormatQNameCheck(const mQNameCheckResult *result, char *buffer, size_t buffer_size) {
+	switch (result->status) {
+		case MSAM_QNAME_NOT_REQUIRED:
+			snprintf(
+				buffer, buffer_size,
+				"QNAME grouping check: not required for this operation"
+			);
+			break;
+
+		case MSAM_QNAME_HEADER_CONFIRMED:
+			snprintf(
+				buffer, buffer_size,
+				"QNAME grouping check: confirmed by input header SO:queryname"
+			);
+			break;
+
+		case MSAM_QNAME_SAMPLE_OK:
+			if (result->input_records_checked < QNAME_GROUP_CHECK_RECORDS) {
+				snprintf(
+					buffer, buffer_size,
+					"QNAME grouping check: no QNAME grouping violation detected "
+					"in all %zu records",
+					result->qname_records_checked
+				);
+			} else {
+				snprintf(
+					buffer, buffer_size,
+					"QNAME grouping check: no QNAME grouping violation detected "
+					"in first %zu records",
+					result->qname_records_checked
+				);
+			}
+			break;
+
+		case MSAM_QNAME_SAMPLE_WARNING:
+			snprintf(
+				buffer, buffer_size,
+				"QNAME grouping check: WARNING - no QNAME grouping violation "
+				"detected in first %zu records; %zu mapped records among the "
+				"first %zu input records were consistent with coordinate ordering",
+				result->qname_records_checked,
+				result->mapped_records_checked,
+				result->input_records_checked
+			);
+			break;
+
+		default:
+			mDie("Unknown QNAME grouping check status");
+	}
+}
+
+void mPrintProfileProvenanceGzip(gzFile output, int argc, char *argv[], const mQNameCheckResult *qname_check) {
+	char *command = mBuildCommandLine(argc, argv);
+	char  qname_message[1024];
+
+	mFormatQNameCheck(qname_check, qname_message, sizeof(qname_message));
+
+	gzprintf(output, "# msamtools version: %s\n", PACKAGE_VERSION);
+	gzprintf(output, "# msamtools git commit: %s\n", MSAM_GIT_COMMIT);
+	gzprintf(output, "# Command line: %s\n", command);
+	gzprintf(output, "# %s\n", qname_message);
+
+	free(command);
+}
+
+void mAddSamProvenance(sam_hdr_t *header, int argc, char *argv[], const mQNameCheckResult *qname_check) {
+	char *command = mBuildCommandLine(argc, argv);
+	char  description[1252];
+	char  qname_message[1024];
+
+	mFormatQNameCheck(qname_check, qname_message, sizeof(qname_message));
+	snprintf(
+		description,
+		sizeof(description),
+		"git=%s; %s",
+		MSAM_GIT_COMMIT, qname_message
+	);
+
+	/*
+	 * HTSlib's sam_hdr_add_pg() generates a unique ID if "msamtools"
+	 * already exists and maintains existing @PG chains.
+	 */
+	if (sam_hdr_add_pg(
+		header,
+		PROGRAM,
+		"PN", PROGRAM,
+		"VN", PACKAGE_VERSION,
+		"CL", command,
+		"DS", description,
+		NULL
+	) < 0) {
+		free(command);
+		mDie("Cannot add msamtools @PG record to SAM/BAM header");
+	}
+
+	free(command);
 }
 
 void mMultipleFileError(const char *subprogram, void **argtable) {
-/*
-	fprintf(stderr, "-t required when using multiple input files!\n");
-*/
 	fprintf(stderr, "Multiple input files not supported in %s.\n", subprogram);
 	fprintf(stderr, "Use 'samtools merge' to combine BAM/SAM files.\n");
 	mPrintHelp(subprogram, argtable);
@@ -171,79 +289,196 @@ int mSamClose(mSamFile *stream) {
 	ret = sam_close(stream->file);
 	sam_hdr_destroy(stream->header);
 	free(stream);
-
 	return ret;
 }
 
-/*
- * Ensure that a list of sam/bam files have the same header
- */
-int mHeaderCheck(int count, const char* filenames[], const char *inmode) {
-	int i, j;
-	mSamFile  *sam1    = mOpenSamInput(filenames[0], inmode);
-	sam_hdr_t *header1 = sam1->header;
-	if (header1 == 0)
-		mDie("No header found in %s. Please fix your bamfile!", filenames[0]);
-	for (i=1; i<count; i++) {
-		mSamFile  *sam2 = mOpenSamInput(filenames[i], inmode);
-		sam_hdr_t *header2 = sam2->header;
-		if (header2 == 0)
-			mDie("No header found in %s. Please fix your bamfile!", filenames[i]);
-		if (header1->n_targets != header2->n_targets) {
-			fprintf(stderr, "%s vs %s:\n", filenames[0], filenames[i]);
-			fprintf(stderr, "Sequence count in BAM header differs:\n");
-			fprintf(stderr, "%d vs %d\n", header1->n_targets, header2->n_targets);
-			mDie("@SQ count mismatch");
+mQNameCheckResult mSamCheckQNameGrouping(mSamFile *input) {
+	mQNameCheckResult result;
+	kstring_t        sort_order = {0, 0, NULL};
+	bam1_t          *record;
+	zoeHash          closed_qnames;
+    zoeVec           allocated_groups;
+	char            *current_qname = NULL;
+	size_t           current_group_first = 0;
+	size_t           record_number = 0;
+	size_t           i;
+	int              read_status;
+	int              coordinate_ordered = 1;
+	int              coordinate_relevant = 0;
+	int              have_previous_mapped = 0;
+	int32_t          previous_tid = -1;
+	hts_pos_t        previous_pos = -1;
+
+	result.status = MSAM_QNAME_SAMPLE_OK;
+	result.qname_records_checked = 0;
+	result.input_records_checked = 0;
+	result.mapped_records_checked = 0;
+
+	/* Explicit header declarations are authoritative. */
+	read_status = sam_hdr_find_tag_hd(input->header, "SO", &sort_order);
+	if (read_status >= 0 && sort_order.s != NULL) {
+		if (strcmp(sort_order.s, "queryname") == 0) {
+			result.status = MSAM_QNAME_HEADER_CONFIRMED;
+			free(sort_order.s);
+			return result;
 		}
-		for (j=1; j<header1->n_targets; j++) {
-			if (strcmp(header1->target_name[j], header2->target_name[j]) != 0) {
-				fprintf(stderr, "%s vs %s:\n", filenames[0], filenames[i]);
-				fprintf(stderr, "Sequence name for target %d in BAM header differs:\n", j);
-				fprintf(stderr, "%s vs %s\n", header1->target_name[j], header2->target_name[j]);
-				mDie("@SQ name mismatch");
+		if (strcmp(sort_order.s, "coordinate") == 0) {
+			free(sort_order.s);
+			mDie(
+				"Input SAM/BAM declares 'SO:coordinate', but this operation "
+				"requires records to be grouped by QNAME.\n"
+				"             Please name-sort the input, for example with "
+				"'samtools sort -n input.bam -o input.name_sorted.bam'."
+			);
+		}
+	}
+	free(sort_order.s);
+
+	record = bam_init1();
+	if (record == NULL)
+		mDie("Out of memory while checking QNAME grouping");
+
+	input->replay_buffer = (bam1_t**) calloc(
+		COORD_ORDER_CHECK_RECORDS, sizeof(bam1_t*)
+	);
+	if (input->replay_buffer == NULL) {
+		bam_destroy1(record);
+		mDie("Out of memory while buffering SAM/BAM records");
+	}
+	input->replay_count = 0;
+	input->replay_index = 0;
+
+	closed_qnames    = zoeNewHash();
+	allocated_groups = zoeNewVec();
+
+	for (i=0; i<COORD_ORDER_CHECK_RECORDS; i++) {
+		const char *qname;
+
+		read_status = sam_read1(input->file, input->header, record);
+		if (read_status < 0)
+			break;
+
+		record_number++;
+		result.input_records_checked++;
+
+		input->replay_buffer[input->replay_count] = bam_dup1(record);
+		if (input->replay_buffer[input->replay_count] == NULL)
+			mDie("Out of memory while buffering SAM/BAM record");
+		input->replay_count++;
+
+		qname = bam_get_qname(record);
+
+		/*
+		 * A QNAME that reappears after its contiguous group has closed is
+		 * definitive evidence that the input is unsuitable.
+		 */
+		if (record_number <= QNAME_GROUP_CHECK_RECORDS) {
+			result.qname_records_checked++;
+
+			if (current_qname == NULL) {
+				current_qname = (char*) mMalloc(strlen(qname) + 1);
+				strcpy(current_qname, qname);
+				current_group_first = record_number;
+			} else if (strcmp(qname, current_qname) != 0) {
+				mClosedQNameGroup *closed;
+				mClosedQNameGroup *reopened;
+
+				closed = (mClosedQNameGroup*) mMalloc(
+					sizeof(mClosedQNameGroup)
+				);
+				closed->first_record = current_group_first;
+				closed->last_record = record_number - 1;
+
+				zoeSetHash(closed_qnames, current_qname, closed);
+				zoePushVec(allocated_groups, closed);
+
+				reopened = (mClosedQNameGroup*) zoeGetHash(
+					closed_qnames, qname
+				);
+				if (reopened != NULL) {
+					size_t intervening = (
+						record_number - reopened->last_record - 1
+					);
+					mDie(
+						"SAM/BAM file is not grouped by QNAME. "
+						"Read '%s' reappears at record %zu after its previous "
+						"group ended at record %zu (%zu intervening records). "
+						"Please name-sort the input, for example with "
+						"'samtools sort -n input.bam -o input.name_sorted.bam'.",
+						qname,
+						record_number,
+						reopened->last_record,
+						intervening
+					);
+				}
+
+				mFree(current_qname);
+				current_qname = (char*) mMalloc(strlen(qname) + 1);
+				strcpy(current_qname, qname);
+				current_group_first = record_number;
 			}
 		}
-		mSamClose(sam2);
-	}
-	mSamClose(sam1);
-	return 1;
-}
 
-/*
- * Convenient functions for handling zoeHash
- */
-zoeHash mReadIntegerHash(const char *filename) {
-	char     line[2048];
-	char     key[128];
-	int     *value;
-	FILE    *stream;
-	zoeHash  hash;
+		/*
+		 * Coordinate ordering is only a heuristic.  Inspect mapped records
+		 * and warn, rather than fail, if the sampled prefix is perfectly
+		 * coordinate ordered and the records indicate that templates may
+		 * have multiple SAM/BAM records.
+		 */
+		if (!(record->core.flag & BAM_FUNMAP) && record->core.tid >= 0) {
+			result.mapped_records_checked++;
 
-	stream = fopen(filename, "r");
-	if (stream == NULL)
-		mDie("Cannot open file: %s\n", filename);
+			if (have_previous_mapped) {
+				if (
+					record->core.tid < previous_tid ||
+					(
+						record->core.tid == previous_tid &&
+						record->core.pos < previous_pos
+					)
+				) {
+					coordinate_ordered = 0;
+				}
+			}
 
-	value = (int*) mCalloc(1, sizeof(int));;
-	hash = zoeNewHash();
-	while (fgets(line, sizeof(line), stream) != NULL) {
-		if (sscanf(line, "%s\t%d", key, value) == 2) {
-			zoeSetHash(hash, key, value);
+			previous_tid = record->core.tid;
+			previous_pos = record->core.pos;
+			have_previous_mapped = 1;
 		}
-		value = (int*) mCalloc(1, sizeof(int));
-	}
-	fclose(stream);
-	mFree(value);
-	return hash;
-}
 
-void mEmptyZoeHash(zoeHash hash) {
-	int    i;
-	zoeVec vals;
-	if (hash == NULL) 
-		return;
-	vals = zoeValsOfHash(hash); 
-	for (i=0; i<vals->size; i++) {
-		mFree(vals->elem[i]);
+		if (
+			record->core.flag &
+			(BAM_FPAIRED | BAM_FSECONDARY | BAM_FSUPPLEMENTARY)
+		) {
+			coordinate_relevant = 1;
+		}
 	}
-	zoeDeleteVec(vals);
+
+	if (current_qname != NULL)
+		mFree(current_qname);
+
+	for (i=0; i<(size_t)allocated_groups->size; i++) {
+		mFree(allocated_groups->elem[i]);
+	}
+	zoeDeleteVec(allocated_groups);
+	zoeDeleteHash(closed_qnames);
+	bam_destroy1(record);
+
+	if (input->replay_count == 0) {
+		free(input->replay_buffer);
+		input->replay_buffer = NULL;
+	}
+
+	if (
+		coordinate_ordered &&
+		coordinate_relevant &&
+		result.mapped_records_checked >= COORD_ORDER_MIN_RECORDS
+	) {
+		char warning[1024];
+
+		result.status = MSAM_QNAME_SAMPLE_WARNING;
+		mFormatQNameCheck(&result, warning, sizeof(warning));
+		fprintf(stderr, "WARNING: %s\n", warning);
+	}
+
+	return result;
 }

--- a/msam_profile.c
+++ b/msam_profile.c
@@ -435,19 +435,32 @@ void mPrintInsertStats(gzFile stream, int align, const char* type, int number, i
 	if (total > 0) {
 		width = 1 + log10(total);
 	}
+
+    /* Write the read type */
 	gzprintf(stream, "# ");
 	if (align == LEFT_ALIGN) {
 		gzprintf(stream, "%-20s: ", type);
 	} else {
 		gzprintf(stream, "%20s: ", type);
 	}
-	gzprintf(stream, "%*d (", width, number);
+
+    /* Write number of inserts */
+    /* For total inserts, if --total was not defined, write NA */
+    if (strcmp(type, "Total inserts") == 0 && number == -1) {
+        gzprintf(stream, "%*s (", width, "NA");
+    } else {
+        gzprintf(stream, "%*d (", width, number);
+    }
+
+    /* Write percentage */
 	if (total > 0) {
 		gzprintf(stream, "%6.2f", 100.0*number/total);
 	} else {
 		gzprintf(stream, "%6s", "NA");
 	}
 	gzprintf(stream, "%%)");
+
+    /* close */
 	if (post_text != NULL) {
 		gzprintf(stream, " %s\n", post_text);
 	} else {

--- a/msam_profile.c
+++ b/msam_profile.c
@@ -465,6 +465,7 @@ int msam_profile_main(int argc, char* argv[]) {
 	const char      *inmode;
 	mSamFile        *input  = NULL;
 	mMatrix         *abundance;
+	mQNameCheckResult qname_check;
 	int              share_type    = -1;
 	int              unit_type     = -1;
 	int              length_normalize = 1;
@@ -638,13 +639,13 @@ int msam_profile_main(int argc, char* argv[]) {
 		}
 	}
 
-	/* Set input/output modes */
+	/* Set input mode */
 
-	inmode = M_INPUT_MODE(arg_samin);
-
-	infile = arg_samfile->filename[0];
-	input = mOpenSamInput(infile, inmode);
+	inmode         = M_INPUT_MODE(arg_samin);
+	infile         = arg_samfile->filename[0];
+	input          = mOpenSamInput(infile, inmode);
 	global->header = input->header;
+	qname_check    = mSamCheckQNameGrouping(input);
 
 	/* multi-mapper share type */
 
@@ -726,6 +727,7 @@ int msam_profile_main(int argc, char* argv[]) {
 			mFree(seqname);
 		}
 		mSafeCloseFile(def_stream, 0);
+
 		keys = zoeKeysOfHash(genomes);
 		global->n_features = keys->size;
 		for (i=0; i<keys->size; i++) {
@@ -823,8 +825,8 @@ int msam_profile_main(int argc, char* argv[]) {
 		output = gzopen(arg_out->sval[0], "wb");
 	}
 
-	/* Print command-line for book-keeping */
-	mPrintCommandLineGzip(output, argc, argv);
+	/* Print structured provenance and QNAME grouping status */
+	mPrintProfileProvenanceGzip(output, argc, argv, &qname_check);
 
 	/* Print header with insert mapping stats */
 	effective_inserts = mapped_inserts - global->purged_insert_count;

--- a/validation/validate_profiles.py
+++ b/validation/validate_profiles.py
@@ -136,7 +136,7 @@ ECOLI_SAKAI_ASSEMBLY = "GCF_000008865.2"
 PROFILE_MULTI_RE = re.compile(r"Multiple mapped\s*:\s*([0-9]+)")
 PROFILE_TOTAL_RE = re.compile(r"Total inserts\s*:\s*([0-9]+)")
 PROFILE_MAPPED_RE = re.compile(r"Mapped inserts\s*:\s*([0-9]+)")
-PROFILE_VERSION_RE = re.compile(r"^# msamtools version\s+(.+?)\s*$", re.MULTILINE)
+PROFILE_VERSION_RE = re.compile(r"^# msamtools version:\s+(.+?)\s*$", re.MULTILINE)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:


### PR DESCRIPTION
## Summary

Add input-order validation for msamtools operations that require alignments
to be grouped by QNAME.

This prevents silently incorrect results when `profile`, `filter --besthit`, or
`filter --uniqhit` are run on unsuitable input, while preserving streaming support.

## Behavior

For operations requiring QNAME grouping:

- trust input explicitly marked with `SO:queryname`;
- reject input explicitly marked with `SO:coordinate`;
- inspect the first 10,000 records for QNAMEs that reappear after their
  contiguous group has ended and fail if such a violation is found;
- inspect up to 100,000 records for coordinate-like ordering;
- emit a warning, but continue processing, when the sampled records appear
  coordinate ordered without an observed QNAME-grouping violation.

The sampled prefix is buffered and replayed transparently through `mSamRead()`,
so stdin/pipe workflows remain supported and downstream grouping logic sees an
uninterrupted alignment stream.

Ordinary filtering operations that do not depend on QNAME grouping are not
subject to these checks.

## Provenance

Filtered SAM/BAM output now records each msamtools invocation in a structured
`@PG` record containing:

- msamtools version;
- Git commit;
- full command line;
- QNAME-grouping check status.

HTSlib maintains unique program IDs and `PP` links between successive processing
steps.

Profile output records the equivalent provenance information in structured
comment lines.

## Other changes

- validate that at least one filter operation is requested before opening or
  writing output;
- remove obsolete helper functions, including unused ZOE hash cleanup code;
- retain replay-buffer cleanup and streaming-safe ownership of buffered records.